### PR TITLE
Remove deprecation warnings e refatora o serviço SchoolDayChecker

### DIFF
--- a/app/services/school_day_checker.rb
+++ b/app/services/school_day_checker.rb
@@ -1,100 +1,129 @@
 class SchoolDayChecker
-  def initialize(school_calendar, date, grade_id, classroom_id, discipline_id)
-    raise ArgumentError unless school_calendar.present? && date.present?
+  CHECKERS_WHEN_CLASSROOM_PRESENT = [:discipline, :classroom, :classroom_grade, :course, :classroom_global].freeze
+  CHECKERS_WHEN_CLASSROOM_NIL = [:grade, :global].freeze
+
+  def initialize(
+    school_calendar,
+    date,
+    grade_or_grade_id = nil,
+    classroom_or_classroom_id = nil,
+    discipline_or_discipline_id = nil
+  )
+    raise ArgumentError if school_calendar.nil? && date.nil?
 
     @school_calendar = school_calendar
     @date = date
-    @grade_id = grade_id
-    @classroom_id = classroom_id
-    @discipline_id = discipline_id
+    @grade_id = fetch_id(grade_or_grade_id)
+    @classroom_id = fetch_id(classroom_or_classroom_id)
+    @discipline_id = fetch_id(discipline_or_discipline_id)
   end
 
   def school_day?
-    date_is_school_day?(@date)
-  end
-
-  def next_school_day
-    date = @date
-
-    while not date_is_school_day?(date)
-      date = date.next_day
+    for_each_checker(checker_methods) do |result|
+      return result unless result.nil?
     end
 
-    date
+    return false if classroom && classroom.calendar && classroom.calendar.classroom_step(@date).nil?
+    return false if @school_calendar.step(@date).nil?
+
+    weekday?
   end
 
   private
 
-  def date_is_school_day?(date)
-    events_by_date = @school_calendar.events.by_date(date)
-    events_by_date_without_frequency = events_by_date.without_frequency
-    events_by_date_with_frequency = events_by_date.with_frequency
-
-    if @classroom_id.present?
-      if @discipline_id.present?
-        return false if any_discipline_event?(events_by_date_without_frequency, @grade_id, @classroom_id, @discipline_id)
-        return true if any_discipline_event?(events_by_date_with_frequency, @grade_id, @classroom_id, @discipline_id)
-      end
-
-      return false if any_classroom_event?(events_by_date_without_frequency, @grade_id, @classroom_id)
-      return true if any_classroom_event?(events_by_date_with_frequency, @grade_id, @classroom_id)
-
-      return false if any_grade_event?(events_by_date_without_frequency.by_period(classroom.period), @grade_id)
-      return true if any_grade_event?(events_by_date_with_frequency.by_period(classroom.period), @grade_id)
-      return false if any_course_event?(events_by_date_without_frequency.by_period(classroom.period), grade.course_id)
-      return true if any_course_event?(events_by_date_with_frequency.by_period(classroom.period), grade.course_id)
-
-      return false if any_global_event?(events_by_date_without_frequency.by_period(classroom.period))
-      return true if any_global_event?(events_by_date_with_frequency.by_period(classroom.period))
-
-    else
-
-      if @grade_id.present?
-        return false if any_grade_event?(events_by_date_without_frequency, @grade_id)
-        return true if any_grade_event?(events_by_date_with_frequency, @grade_id)
-      end
-
-      return false if any_global_event?(events_by_date_without_frequency)
-      return true if any_global_event?(events_by_date_with_frequency)
-    end
-
-    if @classroom_id.present? && classroom.try(:calendar)
-      return false if classroom.calendar.classroom_step(date).nil?
-    else
-      return false if @school_calendar.step(date).nil?
-    end
-
-    ![0, 6].include? date.wday
+  def events_by_date
+    @events_by_date ||= @school_calendar.events.by_date(@date)
   end
 
-  def any_discipline_event?(query, grade_id, classroom_id, discipline_id)
-    query.by_grade(grade_id)
-         .by_classroom_id(classroom_id)
-         .by_discipline_id(discipline_id)
+  def events_by_date_without_frequency
+    @events_by_date_without_frequency ||= events_by_date.without_frequency
+  end
+
+  def events_by_date_with_frequency
+    @events_by_date_with_frequency ||= events_by_date.with_frequency
+  end
+
+  def checker_methods
+    return CHECKERS_WHEN_CLASSROOM_NIL if @classroom_id.nil?
+
+    CHECKERS_WHEN_CLASSROOM_PRESENT
+  end
+
+  def for_each_checker(keys)
+    keys.each do |key|
+      yield(send("any_#{key}_event?"))
+    end
+  end
+
+  def weekday?
+    !(@date.saturday? || @date.sunday?)
+  end
+
+  def any_discipline_event?
+    return if @discipline_id.nil?
+    return false if any_discipline_event_found?(events_by_date_without_frequency)
+    return true if any_discipline_event_found?(events_by_date_with_frequency)
+  end
+
+  def any_discipline_event_found?(query)
+    query.by_grade(@grade_id)
+         .by_classroom_id(@classroom_id)
+         .by_discipline_id(@discipline_id)
          .any?
   end
 
-  def any_classroom_event?(query, grade_id, classroom_id)
-    query.by_grade(grade_id)
+  def any_classroom_event?
+    return false if any_classroom_event_found?(events_by_date_without_frequency)
+    return true if any_classroom_event_found?(events_by_date_with_frequency)
+  end
+
+  def any_classroom_event_found?(query)
+    query.by_grade(@grade_id)
          .without_discipline
-         .by_classroom_id(classroom_id)
+         .by_classroom_id(@classroom_id)
          .any?
   end
 
-  def any_grade_event?(query, grade_id)
-    query.by_grade(grade_id)
+  def any_classroom_grade_event?
+    return false if any_grade_event_found?(events_by_date_without_frequency.by_period(classroom.period))
+    return true if any_grade_event_found?(events_by_date_with_frequency.by_period(classroom.period))
+  end
+
+  def any_grade_event?
+    return if @grade_id.present?
+    return false if any_grade_event_found?(events_by_date_without_frequency)
+    return true if any_grade_event_found?(events_by_date_with_frequency)
+  end
+
+  def any_grade_event_found?(query)
+    query.by_grade(@grade_id)
          .without_classroom
          .any?
   end
 
-  def any_course_event?(query, course_id)
-    query.by_course(course_id)
+  def any_course_event?
+    return false if any_course_event_found?(events_by_date_without_frequency.by_period(classroom.period))
+    return true if any_course_event_found?(events_by_date_with_frequency.by_period(classroom.period))
+  end
+
+  def any_course_event_found?(query)
+    query.by_course(grade.course_id)
          .without_grade
          .without_classroom
          .any?
   end
 
-  def any_global_event?(query)
+  def any_global_event?
+    return false if any_global_event_found?(events_by_date_without_frequency)
+    return true if any_global_event_found?(events_by_date_with_frequency)
+  end
+
+  def any_classroom_global_event?
+    return false if any_global_event_found?(events_by_date_without_frequency.by_period(classroom.period))
+    return true if any_global_event_found?(events_by_date_with_frequency.by_period(classroom.period))
+  end
+
+  def any_global_event_found?(query)
     query.without_course
          .without_grade
          .without_classroom
@@ -102,10 +131,20 @@ class SchoolDayChecker
   end
 
   def classroom
+    return if @classroom_id.nil?
+
     @classroom ||= Classroom.find(@classroom_id)
   end
 
   def grade
+    return if @grade_id.nil?
+
     @grade ||= Grade.find(@grade_id)
+  end
+
+  def fetch_id(record_or_record_id)
+    return record_or_record_id.id if record_or_record_id.is_a?(ActiveRecord::Base)
+
+    record_or_record_id
   end
 end


### PR DESCRIPTION
Refatora o serviço SchoolDayChecker aplicando boas práticas de desenvolvimento e adequa ao style guide da Portabilis, a api publica não é alterada.

## Descrição
O serviço foi refatorado para se adequar ao style guide, reduzida a passagem de parâmetros quando variáveis de instância podiam ser usadas, melhorado a legibilidade, melhorado as responsabilidades do métodos e como consequência reduzido a quantidade de linhas de cada um e removido métodos não utilizados.

## Contexto e motivação
Durante a refatoração do serviço ExamPoster::NumericalExamPoster foi revelado um deprecation warning nesta classe, analisando mais a fundo um refatoração se fez necessária visto que a classe não seguia em 100% o style guide e algumas boas práticas de desenvolvimento poderiam ser aplicadas.

Resolve esta issue: https://github.com/portabilis/i-diario/issues/30

## Tipos de alterações
- ✅ Melhoria

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
