### PR TITLE
[WIP] Evita erro adicionando validação

### DIFF
--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -55,6 +55,7 @@ class ConceptualExamsController < ApplicationController
     @conceptual_exam = find_or_initialize_conceptual_exam
     authorize @conceptual_exam
     @conceptual_exam.assign_attributes(resource_params)
+    @conceptual_exam.merge_conceptual_exam_values
     @conceptual_exam.step_number = @conceptual_exam.step.try(:step_number)
     @conceptual_exam.teacher_id = current_teacher_id
 

--- a/app/models/conceptual_exam.rb
+++ b/app/models/conceptual_exam.rb
@@ -99,6 +99,23 @@ class ConceptualExam < ActiveRecord::Base
     end
   end
 
+  def merge_conceptual_exam_values
+    grouped_conceptual_exam_values = conceptual_exam_values.group_by { |e|
+      [e.conceptual_exam_id, e.discipline_id]
+    }
+
+    self.conceptual_exam_values = grouped_conceptual_exam_values.map do |_key, conceptual_exam_values|
+      next conceptual_exam_values.first if conceptual_exam_values.size == 1
+
+      persisted = conceptual_exam_values.find(&:persisted?)
+      new_record = conceptual_exam_values.find(&:new_record?)
+
+      persisted.value = new_record.value if new_record.present?
+
+      persisted
+    end
+  end
+
   private
 
   def student_must_have_conceptual_exam_score_type

--- a/app/models/conceptual_exam_value.rb
+++ b/app/models/conceptual_exam_value.rb
@@ -10,6 +10,8 @@ class ConceptualExamValue < ActiveRecord::Base
   validates :conceptual_exam, presence: true
   validates :discipline_id, presence: true
 
+  validates :conceptual_exam_id, uniqueness: { scope: :discipline_id }
+
   before_destroy :valid_for_destruction?
 
   scope :by_discipline_id, lambda { |discipline_id| where(discipline_id: discipline_id) }

--- a/spec/models/conceptual_exam_spec.rb
+++ b/spec/models/conceptual_exam_spec.rb
@@ -43,4 +43,43 @@ RSpec.describe ConceptualExam, type: :model do
       end
     end
   end
+
+  describe '#merge_conceptual_exam_values' do
+    it 'overrides the new value over the persisted one' do
+      subject.save!(validate: false)
+      conceptual_exam_value = create(:conceptual_exam_value, value: 100, conceptual_exam: subject)
+      expect(subject.conceptual_exam_values.first.value).to eq 100
+
+      attributes = {
+        conceptual_exam_values_attributes: {
+          '1' => {
+            discipline_id: conceptual_exam_value.discipline_id,
+            value: 200
+          },
+          '2' => {
+            discipline_id: Discipline.first.id,
+            value: 300
+          }
+        }
+      }
+      subject.assign_attributes(attributes)
+
+      subject.merge_conceptual_exam_values
+
+      expect(subject.conceptual_exam_values.size).to eq 2
+      expect(subject.conceptual_exam_values.first.value).to eq 200
+      expect(subject.conceptual_exam_values.last.value).to eq 300
+    end
+
+    it 'maintains only the persited if do not have new values' do
+      subject.save!(validate: false)
+      create(:conceptual_exam_value, value: 100, conceptual_exam: subject)
+      expect(subject.conceptual_exam_values.first.value).to eq 100
+
+      subject.merge_conceptual_exam_values
+
+      expect(subject.conceptual_exam_values.size).to eq 1
+      expect(subject.conceptual_exam_values.first.value).to eq 100
+    end
+  end
 end


### PR DESCRIPTION
Adicionado validação de unicidade em conceptual_exam_value para evitar
erro ActiveRecord::RecordNotUnique.

Foi necessário tratar também para quando tiver novos valores,
sobrescrever os persistidos. Isso vai permitir o usuário abrir duas
telas para salvar avaliação conceitual e vai manter apenas o valor da
última persistência.

https://app.honeybadger.io/fault/54397/6b9526364ea2105b7c1729f552412b11

## TODO:
- [ ] Cobrir com testes unitários
- [ ] Cobrir com testes de integração