### PR TITLE
Corrige o erro de atualização do Debian Jessie no Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.2.6
 
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update -qq
 RUN apt-get install -y build-essential libpq-dev nodejs npm nodejs-legacy
 RUN npm install -g phantomjs-prebuilt


### PR DESCRIPTION
Como o Jessie foi arquivado, o update anterior não conseguia rodar pois
apontava para uma URL inválida.

<!--- Informe um resumo das alterações que foram efetuadas no título acima -->

## Descrição
<!--- Descreva em detalhes sua modificação -->
Eu fui querer mexer no projeto e dei de cara com essa questão do update. Não sei se vocês pretendem atualizar o Ruby agora, mas eu achei melhor corrigir o Dockerfile para possibilidade colaboração dentro da estrutura atual. 

Eu recomendaria um upgrade e acho que vou tentar propor aqui pra vocês, mas antes eu preciso rodar os testes :)

## Contexto e motivação
<!--- Por que essas alterações foram necessárias? Quais problema elas resolveram? -->
<!--- Se essa alteração corrige alguma issue, insira o link da issue aqui. (#numero-da-issue) -->

Encontrei o projeto e achei que valeria contribuir e receber feedbacks de vocês. Eu tenho dominio do docker, então pra mim era fácil ajustar algumas coisas antes de começar de verdade.

## Tipos de alterações
<!--- Que tipo de mudanças seu código apresenta? -->
<!--- Remova todas as linhas que não foram aplicadas. -->
- Correção de bugs (Não quebra outras funcionalidades)