### PR TITLE
Adiciona perform_in_entity para workers e os refatora

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ end
 group :test, :development do
   gem 'bullet', '4.14.10'
 end
+
+gem "thread-parent", "~> 1.0"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -131,7 +131,7 @@ class ApplicationController < ActionController::Base
 
   def current_entity
     @current_entity ||= Entity.find_by(domain: request.host)
-    Entity.current = @current_entity
+    EntitySingletoon.set @current_entity
   end
   helper_method :current_entity
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,13 +103,13 @@ module ApplicationHelper
   end
 
   def entity_copyright
-    Rails.cache.fetch("#{Entity.current.try(:id)}_entity_copyright", expires_in: 10.minutes) do
+    Rails.cache.fetch("#{EntitySingletoon.current.try(:id)}_entity_copyright", expires_in: 10.minutes) do
       "© #{GeneralConfiguration.current.copyright_name} #{Time.zone.today.year}"
     end
   end
 
   def entity_website
-    Rails.cache.fetch("#{Entity.current.try(:id)}_entity_website", expires_in: 10.minutes) do
+    Rails.cache.fetch("#{EntitySingletoon.current.try(:id)}_entity_website", expires_in: 10.minutes) do
       GeneralConfiguration.current.support_url
     end
   end

--- a/app/lib/entity_singletoon.rb
+++ b/app/lib/entity_singletoon.rb
@@ -1,0 +1,43 @@
+require 'thread_parent'
+
+module EntitySingletoon
+  extend self
+
+  def set entity
+    Thread.current[:entity] = entity
+  end
+
+  def current
+    entity_thread_or_parentest[:entity]
+  end
+
+  def with entity, &block
+    thread = Thread.current
+
+    prev_entity = thread[:entity]
+    begin
+      thread[:entity] = entity
+  
+      entity.using_connection &block
+    ensure
+      thread[:entity] = prev_entity
+    end
+
+  end
+  
+  def entity_thread_or_parentest
+    thread = Thread.current
+
+    while not thread.key?(:entity) and thread.parent
+      thread = thread.parent
+    end
+
+    thread
+  end
+
+  def current_domain
+    raise Exception.new("Entity not found") if self.current.blank?
+
+    self.current.domain
+  end
+end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,19 +1,11 @@
 class Entity < ActiveRecord::Base
   acts_as_copy_target
 
-  cattr_accessor :current
-
   validates :name, :domain, :config, presence: true
   validates :domain, uniqueness: { case_sensitive: false }, allow_blank: true
 
   scope :need_migration, -> { where(migrate: true) }
   scope :active, -> { where(disabled: false) }
-
-  def self.current_domain
-    raise Exception.new("Entity not found") if self.current.blank?
-
-    self.current.domain
-  end
 
   def using_connection(&block)
     Honeybadger.context(entity: { name: name, id: id })

--- a/app/models/terms_dictionary.rb
+++ b/app/models/terms_dictionary.rb
@@ -11,7 +11,7 @@ class TermsDictionary < ActiveRecord::Base
   end
 
   def self.cached_current
-    Rails.cache.fetch("#{Entity.current.id}_current_terms_dictionary", expires_in: 10.minutes) do
+    Rails.cache.fetch("#{EntitySingletoon.current.id}_current_terms_dictionary", expires_in: 10.minutes) do
       self.current
     end
   end

--- a/app/services/student_recovery_average_calculator.rb
+++ b/app/services/student_recovery_average_calculator.rb
@@ -11,7 +11,7 @@ class StudentRecoveryAverageCalculator
       parallel_recovery_average
     elsif recovery_type == RecoveryTypes::SPECIFIC
       # FIXME Remove this when possible
-      if Entity.current.name == 'saomigueldoscampos' || Entity.current.name == 'clientetest3'
+      if EntitySingletoon.current.name == 'saomigueldoscampos' || EntitySingletoon.current.name == 'clientetest3'
         specific_recovery_sum
       else
         specific_recovery_average

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -3,5 +3,5 @@
 <p>Você pode confirmar sua conta através do link abaixo:</p>
 
 <p><%= link_to 'Confirmo minha conta', confirmation_url(@resource,
-                                                        host: Entity.current_domain,
+                                                        host: EntitySingletoon.current_domain,
                                                         confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,7 @@
 <p>Alguém solicitou a mudança de sua senha. Você pode fazer isso através do link abaixo.</p>
 
 <p><%= link_to 'Alterar minha senha', edit_password_url(@resource,
-                                                        host: Entity.current_domain,
+                                                        host: EntitySingletoon.current_domain,
                                                         reset_password_token: @token) %></p>
 
 <p>Se não foi você quem solicitou, por favor, ignore este e-mail.</p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -5,5 +5,5 @@
 <p>Clique no link abaixo para desbloquear sua conta:</p>
 
 <p><%= link_to 'Desbloquear minha conta', unlock_url(@resource,
-                                                     host: Entity.current_domain,
+                                                     host: EntitySingletoon.current_domain,
                                                      unlock_token: @token) %></p>

--- a/app/workers/daily_frequency_creator_worker.rb
+++ b/app/workers/daily_frequency_creator_worker.rb
@@ -1,35 +1,32 @@
 class DailyFrequencyCreatorWorker
   include Sidekiq::Worker
+  include EntityWorker
 
   sidekiq_options(queue: :daily_frequency_creator)
 
-  def perform(entity_id, daily_frequency_id, worker_batch_id)
-    entity = Entity.find(entity_id)
+  def perform_in_entity(daily_frequency_id, worker_batch_id)
+    daily_frequency = DailyFrequency.find(daily_frequency_id)
 
-    entity.using_connection do
-      daily_frequency = DailyFrequency.find(daily_frequency_id)
+    DailyFrequenciesCreator.new({
+      unity_id: daily_frequency.unity_id,
+      classroom_id: daily_frequency.classroom_id,
+      frequency_date: daily_frequency.frequency_date,
+      class_numbers: [daily_frequency.class_number],
+      discipline_id: daily_frequency.discipline_id,
+      school_calendar: daily_frequency.school_calendar,
+      origin: OriginTypes::WORKER
+    }).find_or_create!
 
-      DailyFrequenciesCreator.new({
-        unity_id: daily_frequency.unity_id,
-        classroom_id: daily_frequency.classroom_id,
-        frequency_date: daily_frequency.frequency_date,
-        class_numbers: [daily_frequency.class_number],
-        discipline_id: daily_frequency.discipline_id,
-        school_calendar: daily_frequency.school_calendar,
-        origin: OriginTypes::WORKER
-      }).find_or_create!
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      worker_batch = WorkerBatch.find(worker_batch_id)
+    worker_batch.with_lock do
+      worker_batch.done_workers = (worker_batch.done_workers + 1)
 
-      worker_batch.with_lock do
-        worker_batch.done_workers = (worker_batch.done_workers + 1)
-
-        if Rails.logger.debug?
-          worker_batch.completed_workers = (worker_batch.completed_workers << daily_frequency_id)
-        end
-
-        worker_batch.save!
+      if Rails.logger.debug?
+        worker_batch.completed_workers = (worker_batch.completed_workers << daily_frequency_id)
       end
+
+      worker_batch.save!
     end
   end
 end

--- a/app/workers/delete_invalid_presence_record_worker.rb
+++ b/app/workers/delete_invalid_presence_record_worker.rb
@@ -1,11 +1,10 @@
 class DeleteInvalidPresenceRecordWorker
   include Sidekiq::Worker
+  include EntityWorker
 
   sidekiq_options unique: :until_and_while_executing, queue: :low
 
-  def perform(entity_id, student_id, classroom_id)
-    Entity.find(entity_id).using_connection do
-      DeleteInvalidPresenceRecordService.new(student_id, classroom_id).run!
-    end
+  def perform_in_entity(student_id, classroom_id)
+    DeleteInvalidPresenceRecordService.new(student_id, classroom_id).run!
   end
 end

--- a/app/workers/entity_worker.rb
+++ b/app/workers/entity_worker.rb
@@ -1,14 +1,10 @@
 module EntityWorker
   def perform entity_id, *args
     entity = Entity.find(entity_id)
-    prev_entity = Entity.current
-    Entity.current = entity
 
-    entity.using_connection do
+    EntitySingletoon.with(entity) do
       perform_in_entity *args
     end
-
-    Entity.current = prev_entity
   end
 
   def perform_in_entity *args
@@ -17,7 +13,7 @@ module EntityWorker
 
   module ClassMethods
     def perform_current_entity *args
-      perform_async Entity.current.id, *args
+      perform_async EntitySingletoon.current.id, *args
     end
   end
 

--- a/app/workers/entity_worker.rb
+++ b/app/workers/entity_worker.rb
@@ -1,0 +1,27 @@
+module EntityWorker
+  def perform entity_id, *args
+    entity = Entity.find(entity_id)
+    prev_entity = Entity.current
+    Entity.current = entity
+
+    entity.using_connection do
+      perform_in_entity *args
+    end
+
+    Entity.current = prev_entity
+  end
+
+  def perform_in_entity *args
+    raise NotImplementedError.new("You should implement perform_in_entity method")
+  end
+
+  module ClassMethods
+    def perform_current_entity *args
+      perform_async Entity.current.id, *args
+    end
+  end
+
+  def self.included base
+    base.extend ClassMethods
+  end
+end

--- a/app/workers/ieducar_exam_posting_worker.rb
+++ b/app/workers/ieducar_exam_posting_worker.rb
@@ -24,17 +24,17 @@ class IeducarExamPostingWorker
 
     case posting.post_type
     when ApiPostingTypes::NUMERICAL_EXAM
-      ExamPoster::NumericalExamPoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::NumericalExamPoster.post!(posting, EntitySingletoon.current.id, queue)
     when ApiPostingTypes::CONCEPTUAL_EXAM
-      ExamPoster::ConceptualExamPoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::ConceptualExamPoster.post!(posting, EntitySingletoon.current.id, queue)
     when ApiPostingTypes::DESCRIPTIVE_EXAM
-      ExamPoster::DescriptiveExamPoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::DescriptiveExamPoster.post!(posting, EntitySingletoon.current.id, queue)
     when ApiPostingTypes::ABSENCE
-      ExamPoster::AbsencePoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::AbsencePoster.post!(posting, EntitySingletoon.current.id, queue)
     when ApiPostingTypes::FINAL_RECOVERY
-      ExamPoster::FinalRecoveryPoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::FinalRecoveryPoster.post!(posting, EntitySingletoon.current.id, queue)
     when ApiPostingTypes::SCHOOL_TERM_RECOVERY
-      ExamPoster::SchoolTermRecoveryPoster.post!(posting, Entity.current.id, queue)
+      ExamPoster::SchoolTermRecoveryPoster.post!(posting, EntitySingletoon.current.id, queue)
     end
   end
 end

--- a/app/workers/ieducar_exam_posting_worker.rb
+++ b/app/workers/ieducar_exam_posting_worker.rb
@@ -1,5 +1,6 @@
 class IeducarExamPostingWorker
   include Sidekiq::Worker
+  include EntityWorker
 
   sidekiq_options retry: 2, queue: :exam_posting, unique: :until_and_while_executing, dead: false
 
@@ -18,26 +19,22 @@ class IeducarExamPostingWorker
     end
   end
 
-  def perform(entity_id, posting_id, queue = 'exam_posting_send')
-    entity = Entity.find(entity_id)
+  def perform_in_entity(posting_id, queue = 'exam_posting_send')
+    posting = IeducarApiExamPosting.find(posting_id)
 
-    entity.using_connection do
-      posting = IeducarApiExamPosting.find(posting_id)
-
-      case posting.post_type
-      when ApiPostingTypes::NUMERICAL_EXAM
-        ExamPoster::NumericalExamPoster.post!(posting, entity_id, queue)
-      when ApiPostingTypes::CONCEPTUAL_EXAM
-        ExamPoster::ConceptualExamPoster.post!(posting, entity_id, queue)
-      when ApiPostingTypes::DESCRIPTIVE_EXAM
-        ExamPoster::DescriptiveExamPoster.post!(posting, entity_id, queue)
-      when ApiPostingTypes::ABSENCE
-        ExamPoster::AbsencePoster.post!(posting, entity_id, queue)
-      when ApiPostingTypes::FINAL_RECOVERY
-        ExamPoster::FinalRecoveryPoster.post!(posting, entity_id, queue)
-      when ApiPostingTypes::SCHOOL_TERM_RECOVERY
-        ExamPoster::SchoolTermRecoveryPoster.post!(posting, entity_id, queue)
-      end
+    case posting.post_type
+    when ApiPostingTypes::NUMERICAL_EXAM
+      ExamPoster::NumericalExamPoster.post!(posting, Entity.current.id, queue)
+    when ApiPostingTypes::CONCEPTUAL_EXAM
+      ExamPoster::ConceptualExamPoster.post!(posting, Entity.current.id, queue)
+    when ApiPostingTypes::DESCRIPTIVE_EXAM
+      ExamPoster::DescriptiveExamPoster.post!(posting, Entity.current.id, queue)
+    when ApiPostingTypes::ABSENCE
+      ExamPoster::AbsencePoster.post!(posting, Entity.current.id, queue)
+    when ApiPostingTypes::FINAL_RECOVERY
+      ExamPoster::FinalRecoveryPoster.post!(posting, Entity.current.id, queue)
+    when ApiPostingTypes::SCHOOL_TERM_RECOVERY
+      ExamPoster::SchoolTermRecoveryPoster.post!(posting, Entity.current.id, queue)
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/courses_grades_classrooms_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/courses_grades_classrooms_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class CoursesGradesClassroomsSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        CoursesGradesClassroomsSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      CoursesGradesClassroomsSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/deficiencies_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/deficiencies_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class DeficienciesSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        DeficienciesSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      DeficienciesSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/disciplines_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/disciplines_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class DisciplinesSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        DisciplinesSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      DisciplinesSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/exam_rules_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/exam_rules_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class ExamRulesSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id, years)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id, years)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        ExamRulesSynchronizer.synchronize!(synchronization, worker_batch, years)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      ExamRulesSynchronizer.synchronize!(synchronization, worker_batch, years)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/knowledge_areas_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/knowledge_areas_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class KnowledgeAreasSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        KnowledgeAreasSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      KnowledgeAreasSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/recovery_exam_rules_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/recovery_exam_rules_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class RecoveryExamRulesSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        RecoveryExamRulesSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      RecoveryExamRulesSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/rounding_tables_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/rounding_tables_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class RoundingTablesSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        RoundingTablesSynchronizer.synchronize!(synchronization, worker_batch)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      RoundingTablesSynchronizer.synchronize!(synchronization, worker_batch)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/specific_steps_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/specific_steps_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class SpecificStepsSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id, classroom_id, api_classroom_id)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id, classroom_id, api_classroom_id)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        SpecificStepsSynchronizer.synchronize!(synchronization, worker_batch, classroom_id, api_classroom_id)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      SpecificStepsSynchronizer.synchronize!(synchronization, worker_batch, classroom_id, api_classroom_id)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/student_enrollment_dependence_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/student_enrollment_dependence_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class StudentEnrollmentDependenceSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id, years)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id, years)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        StudentEnrollmentDependenceSynchronizer.synchronize!(synchronization, worker_batch, years)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      StudentEnrollmentDependenceSynchronizer.synchronize!(synchronization, worker_batch, years)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/student_enrollment_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/student_enrollment_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class StudentEnrollmentSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id, years, unity_api_code)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id, years, unity_api_code)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        StudentEnrollmentSynchronizer.synchronize!(synchronization, worker_batch, years, unity_api_code)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      StudentEnrollmentSynchronizer.synchronize!(synchronization, worker_batch, years, unity_api_code)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/ieducar_synchronizer_workers/teachers_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_workers/teachers_synchronizer_worker.rb
@@ -1,20 +1,19 @@
 class TeachersSynchronizerWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, synchronization_id, worker_batch_id, years)
-    Entity.find(entity_id).using_connection do
-      synchronization = IeducarApiSynchronization.find(synchronization_id)
-      worker_batch = WorkerBatch.find(worker_batch_id)
+  def perform_in_entity(synchronization_id, worker_batch_id, years)
+    synchronization = IeducarApiSynchronization.find(synchronization_id)
+    worker_batch = WorkerBatch.find(worker_batch_id)
 
-      begin
-        TeachersSynchronizer.synchronize!(synchronization, worker_batch, years)
-      rescue IeducarApi::Base::ApiError => e
-        synchronization.mark_as_error!(e.message)
-      rescue Exception => exception
-        synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
+    begin
+      TeachersSynchronizer.synchronize!(synchronization, worker_batch, years)
+    rescue IeducarApi::Base::ApiError => e
+      synchronization.mark_as_error!(e.message)
+    rescue Exception => exception
+      synchronization.mark_as_error!('Ocorreu um erro desconhecido.')
 
-        raise exception
-      end
+      raise exception
     end
   end
 end

--- a/app/workers/maintenance_adjustment_worker.rb
+++ b/app/workers/maintenance_adjustment_worker.rb
@@ -1,33 +1,30 @@
 class MaintenanceAdjustmentWorker
   include Sidekiq::Worker
+  include EntityWorker
 
-  def perform(entity_id, unities, user_id, maintenance_adjustment_id)
-    entity = Entity.find(entity_id)
+  def perform_in_entity(unities, user_id, maintenance_adjustment_id)
+    maintenance_adjustment = MaintenanceAdjustment.find(maintenance_adjustment_id)
 
-    entity.using_connection do
-      maintenance_adjustment = MaintenanceAdjustment.find(maintenance_adjustment_id)
+    begin
+      maintenance_adjustment.update_attribute(:status, MaintenanceAdjustmentStatus::IN_PROGRESS)
 
-      begin
-        maintenance_adjustment.update_attribute(:status, MaintenanceAdjustmentStatus::IN_PROGRESS)
-
-        case maintenance_adjustment.kind
-          when MaintenanceAdjustmentKinds::ABSENCE_ADJUSTMENTS then AbsenceAdjustmentsService.adjust(unities, maintenance_adjustment.year)
-        end
-
-        maintenance_adjustment.update_attributes(
-          status: MaintenanceAdjustmentStatus::COMPLETED,
-          error_message: ''
-        )
-
-        notify_on_message(maintenance_adjustment, user_id)
-      rescue Exception => e
-        Honeybadger.notify(e)
-
-        maintenance_adjustment.update_attributes(
-          status: MaintenanceAdjustmentStatus::ERROR,
-          error_message: e.message
-        )
+      case maintenance_adjustment.kind
+        when MaintenanceAdjustmentKinds::ABSENCE_ADJUSTMENTS then AbsenceAdjustmentsService.adjust(unities, maintenance_adjustment.year)
       end
+
+      maintenance_adjustment.update_attributes(
+        status: MaintenanceAdjustmentStatus::COMPLETED,
+        error_message: ''
+      )
+
+      notify_on_message(maintenance_adjustment, user_id)
+    rescue Exception => e
+      Honeybadger.notify(e)
+
+      maintenance_adjustment.update_attributes(
+        status: MaintenanceAdjustmentStatus::ERROR,
+        error_message: e.message
+      )
     end
   end
 

--- a/spec/lib/entity_singletoon_spec.rb
+++ b/spec/lib/entity_singletoon_spec.rb
@@ -1,0 +1,131 @@
+ require 'spec_helper'
+
+describe EntitySingletoon do
+
+  let!(:entity) { create(:entity, domain: :foo, config: { database: "entity" }) }
+  let!(:entity_bar) { create(:entity, domain: :bar, config: { database: "bar" }) }
+  let!(:entity_baz) { create(:entity, domain: :baz, config: { database: "baz" }) }
+
+  describe "#current" do
+    context "no entity setted" do
+      it "should return nil" do
+        expect(EntitySingletoon.current).to eql(nil)
+      end
+    end
+
+    context "with entity setted" do
+      around(:each) do |example|
+        EntitySingletoon.set(entity)
+        example.run
+        EntitySingletoon.set nil
+      end
+      
+      it "should return entity" do
+        expect(EntitySingletoon.current).to eql(entity)
+      end
+    end
+
+    describe "inside with block" do
+
+      context "with no entity setted before" do
+        it "should run in context of entity" do
+          EntitySingletoon.with(entity) do
+            expect(EntitySingletoon.current).to eql(entity)
+          end
+        end
+
+        it "should set nil entity after execute" do
+          EntitySingletoon.with(entity) {}
+          expect(EntitySingletoon.current).to eql(nil)
+        end
+      end
+  
+      context "with entity setted before" do
+
+        around(:each) do |example|
+          EntitySingletoon.set entity_bar
+          example.run
+          EntitySingletoon.set nil
+        end
+        
+        it "should run in context of entity" do
+          EntitySingletoon.with(entity) do
+            expect(EntitySingletoon.current).to eql(entity)
+          end
+        end
+  
+        it "should set previous entity" do
+          EntitySingletoon.with(entity) {}
+          expect(EntitySingletoon.current).to eql(entity_bar)
+        end
+      end
+  
+      context "threads" do
+        it "should be threadsafe" do
+          threads = []
+  
+          EntitySingletoon.with(entity_baz) do
+  
+            Thread.new {
+              expect(EntitySingletoon.current).to eql(entity_baz)
+              Thread.new {
+                expect(EntitySingletoon.current).to eql(entity_baz)
+  
+                EntitySingletoon.with(entity) do
+                  expect(EntitySingletoon.current).to eql(entity)
+                end
+  
+                expect(EntitySingletoon.current).to eql(entity_baz)
+              }.join
+              expect(EntitySingletoon.current).to eql(entity_baz)
+              
+            }.join
+  
+            expect(EntitySingletoon.current).to eql(entity_baz)
+  
+            Thread.new {
+              expect(EntitySingletoon.current).to eql(entity_baz)
+            }.join
+  
+            threads << Thread.new {
+              10.times do
+                expect(EntitySingletoon.current).to eql(entity_baz)
+                sleep 0.03
+              end
+            }
+    
+            threads << Thread.new {
+              EntitySingletoon.with(entity) do
+                10.times do
+                  expect(EntitySingletoon.current).to eql(entity)
+                  sleep 0.03
+                end
+              end
+            }
+    
+            threads << Thread.new {
+              EntitySingletoon.with(entity_bar) do
+                10.times do
+                  sleep 0.03
+                  expect(EntitySingletoon.current).to eql(entity_bar)
+                end
+              end
+            }
+    
+            expect(EntitySingletoon.current).to eql(entity_baz)
+    
+            threads.map &:join
+    
+            expect(EntitySingletoon.current).to eql(entity_baz)
+          end
+  
+          expect(EntitySingletoon.current).to eql(nil)
+        end
+      end
+    end
+  end
+  
+
+  
+  
+end

--- a/spec/workers/entity_worker_spec.rb
+++ b/spec/workers/entity_worker_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe EntityWorker do
     attr_accessor :entity, :args
 
     def perform_in_entity *args
-      @entity = Entity.current
+      @entity = EntitySingletoon.current
       @args = args
     end
   end
@@ -53,7 +53,7 @@ RSpec.describe EntityWorker do
 
   describe ".perform_current_entity" do
     it "should call perform_async with current entity" do
-      Entity.current = entity
+      EntitySingletoon.set entity
 
       allow(DummyWorker).to receive(:perform).with(entity.id, :foo, :bar).and_return(nil)
 

--- a/spec/workers/entity_worker_spec.rb
+++ b/spec/workers/entity_worker_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe EntityWorker do
+  class DummyWorker
+    include EntityWorker
+
+    def self.perform_async *args
+    end
+  end
+
+  class DummyWorkerWithPerformInEntity
+    include EntityWorker
+
+    attr_accessor :entity, :args
+
+    def perform_in_entity *args
+      @entity = Entity.current
+      @args = args
+    end
+  end
+
+  let!(:entity) { create(:entity, domain: :foo) }
+
+  describe '#perform' do
+    subject {
+      DummyWorkerWithPerformInEntity.new.tap do |dummy|
+        dummy.perform entity.id, :arg1, :arg2
+      end
+    }
+
+    it 'should call perform_in_entity within entity context' do
+      expect(subject.entity).to eql(entity)
+    end
+
+    it 'should call perform_in_entity with other args' do
+      expect(subject.args).to eql([:arg1, :arg2])
+    end
+
+    context "without override perform_in_entity" do
+      subject {
+        DummyWorker.new.tap do |dummy|
+          dummy.perform entity.id
+        end
+      }
+
+      it "should raise not implemented error" do
+        expect {
+          subject
+        }.to raise_error(NotImplementedError, "You should implement perform_in_entity method")
+      end
+    end
+  end
+
+  describe ".perform_current_entity" do
+    it "should call perform_async with current entity" do
+      Entity.current = entity
+
+      allow(DummyWorker).to receive(:perform).with(entity.id, :foo, :bar).and_return(nil)
+
+      DummyWorker.perform_current_entity :foo, :bar
+    end
+  end
+
+end


### PR DESCRIPTION
A grande motivação é evitar repetição do código de alteração da entidade e testa-lo.

## Descrição

Cria um EntityWorker
O primeiro argumento de um EntityWorker deve ser o entity_id. O EntityWorker sobrescreve o perform, utiliza o using_connection e chama o método perform_in_entity (sem o entity_id, que é desnecessário)
Adiciona o método `perform_current_entity` para a classe para executar o perform passando a entidade atual.
Refatora o código para incluir o worker e alterar o método perform para perform_in_entity

## Contexto e motivação

Evita duplicação, portanto melhora manutenção
Adiciona testes na mudança ao entity, o que garante que o código será executado no contexto da entidade
Issue #42 

## Tipos de alterações

- ✅ Nova feature (Não quebra outras funcionalidades e adiciona funcionalidades)
