### PR TITLE
Portabilis patch 01/04/2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'webpacker', '~> 4.x'
 instance_eval File.read('Gemfile.plugins') if File.exist?('Gemfile.plugins')
 
 group :development do
-  gem 'rack-mini-profiler'
+  gem 'rack-mini-profiler', '~> 2.3.4'
   gem 'meta_request', '0.7.2'
   gem 'pry-byebug', '3.4.2'
   gem 'pry-remote', '0.1.8'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Latest Release](https://img.shields.io/github/release/portabilis/i-diario.svg?label=latest%20release)](https://github.com/portabilis/i-diario/releases)
-[![Maintainability](https://api.codeclimate.com/v1/badges/92cee0c65548b4b4653b/maintainability)](https://codeclimate.com/github/portabilis/i-diario/maintainability)
 
 # i-Diário
 

--- a/app/assets/javascripts/flash_messages.js
+++ b/app/assets/javascripts/flash_messages.js
@@ -17,3 +17,7 @@ FlashMessages.prototype.warning = function(message) {
 FlashMessages.prototype.error = function(message) {
   this.pop("<div class='alert alert-danger'><i class='fa-fw fa fa-times'></i> " + message + "</div>");
 };
+
+FlashMessages.prototype.info = function(message) {
+  this.pop("<div class='alert alert-info'><i class='fa-fw fa fa-info'></i> " + message + "</div>");
+};

--- a/app/assets/javascripts/views/avaliations/form.js.erb
+++ b/app/assets/javascripts/views/avaliations/form.js.erb
@@ -174,6 +174,10 @@ $(function () {
     });
   }
 
+  if ($('#avaliation_grade_ids').data('elements').length == 2) {
+    $('.avaliation_grades').hide();
+  }
+
   function initFields() {
     if (!!document.getElementById('avaliation_test_setting_id')) {
       updateFieldsBasedOnTestSetting();

--- a/app/assets/javascripts/views/conceptual_exams/form.js
+++ b/app/assets/javascripts/views/conceptual_exams/form.js
@@ -83,7 +83,7 @@ $(function() {
             show_inactive: false,
             date: recorded_at
           };
-  
+
           if (!_.isEmpty(classroom_id) && !_.isEmpty(recorded_at)) {
             $.ajax({
               url: Routes.by_date_student_enrollments_lists_pt_br_path({
@@ -310,6 +310,18 @@ $(function() {
     flashMessages.error('Ocorreu um erro ao buscar as disciplinas dispensadas.');
   };
 
+  function exists_conceptual_exam(conceptual_exam_id) {
+    removeDisciplines();
+    let text_step = $step.closest('div').find('#s2id_conceptual_exam_step_id').find('.select2-choice').text().trim();
+    let student_name = $student.closest('div').find('#s2id_conceptual_exam_student_id').find('.select2-choice').text().trim();
+    let redirect_link = Routes.edit_conceptual_exam_pt_br_path(conceptual_exam_id);
+    let message = `O(a) aluno(a) ${student_name} já possui uma avaliação conceitual na etapa ${text_step}, para modificar a mesma clique aqui <a href="${redirect_link}" style="color: white"><b>Avaliação</b></a>.`;
+    $('#btn-save').attr('disabled', true);
+    $('#btn-save-and-next').attr('disabled', true);
+
+    flashMessages.error(message);
+  }
+
   $student.on('change', function(){
     $.get(
       Routes.find_conceptual_exam_by_student_conceptual_exams_pt_br_path(
@@ -323,9 +335,12 @@ $(function() {
         }
       )
     ).done(function(conceptual_exam_id) {
+      flashMessages.pop('');
       if (conceptual_exam_id) {
-        window.location.href = Routes.edit_conceptual_exam_pt_br_path(conceptual_exam_id);
+        exists_conceptual_exam(conceptual_exam_id);
       } else {
+        $('#btn-save').attr('disabled', false);
+        $('#btn-save-and-next').attr('disabled', false);
         fetchExamRule();
         removeDisciplines();
         fetchDisciplines();

--- a/app/assets/javascripts/views/descriptive_exams/form.js
+++ b/app/assets/javascripts/views/descriptive_exams/form.js
@@ -69,6 +69,9 @@ $(function () {
       }),
       success: function(descriptive_exam_id) {
         if (descriptive_exam_id === null || !$.isNumeric(descriptive_exam_id)) {
+          view_btn.addClass('disabled');
+          view_btn.attr('href', '');
+
           return;
         }
 

--- a/app/assets/javascripts/views/descriptive_exams/form.js
+++ b/app/assets/javascripts/views/descriptive_exams/form.js
@@ -8,7 +8,8 @@ $(function () {
       $stepContainer = $('[data-descriptive-exam-step-container]'),
       should_clear_discipline = true,
       should_clear_step = true,
-      discipline_id = $discipline.val();
+      discipline_id = $discipline.val(),
+      view_btn = $('#view-btn');
 
   if ($opinionType.data('elements').length === 2) {
    $opinionType.attr('readonly', true)
@@ -53,4 +54,27 @@ $(function () {
   });
 
   setFields();
+
+  $step.on('change', function() {
+    let step_id = $step.val(),
+        discipline_id = $discipline.val(),
+        opinion_type = $('#descriptive_exam_opinion_type').val();
+
+    $.ajax({
+      url: Routes.find_descriptive_exams_pt_br_path({
+        discipline_id: discipline_id,
+        step_id: step_id,
+        opinion_type: opinion_type,
+        format: 'json'
+      }),
+      success: function(descriptive_exam_id) {
+        if (descriptive_exam_id === null || !$.isNumeric(descriptive_exam_id)) {
+          return;
+        }
+
+        view_btn.removeClass('disabled');
+        view_btn.attr('href', Routes.descriptive_exam_pt_br_path(descriptive_exam_id))
+      }
+    });
+  })
 });

--- a/app/assets/javascripts/views/descriptive_exams/functions.js
+++ b/app/assets/javascripts/views/descriptive_exams/functions.js
@@ -1,0 +1,68 @@
+function createSummerNote(element, options = {}) {
+  $(element).summernote({
+    lang: 'pt-BR',
+    toolbar: options.toolbar || [],
+    disableDragAndDrop : true,
+    callbacks : {
+      onPaste : function (event) {
+        var thisNote = $(this);
+        var updatePastedText = function(someNote){
+          var original = someNote.summernote('code');
+          var cleaned = CleanPastedHTML(original);
+
+          someNote.summernote('code', cleaned);
+        };
+
+        setTimeout(function () {
+          updatePastedText(thisNote);
+        }, 10);
+      }
+    }
+  });
+
+  if (options.disabled) {
+    $(element).each(function(index, el) {
+      $(el).summernote('disable');
+    })
+  }
+}
+
+function CleanPastedHTML(input) {
+  var stringStripper = /(\n|\r| class=(")?Mso[a-zA-Z]+(")?)/g;
+  var output = input.replace(stringStripper, ' ');
+  var commentSripper = new RegExp('<!--(.*?)-->','g');
+  var output = output.replace(commentSripper, '');
+  var tagStripper = new RegExp('<(/)*(meta|link|span|\\?xml:|st1:|o:|font)(.*?)>','gi');
+  output = output.replace(tagStripper, '');
+  var badTags = getTags(output)
+  for (var i=0; i< badTags.length; i++) {
+    tagStripper = new RegExp('<'+badTags[i]+'.*?'+badTags[i]+'(.*?)>', 'gi');
+    output = output.replace(tagStripper, '');
+  }
+  var badAttributes = ['style', 'start'];
+  for (var i=0; i< badAttributes.length; i++) {
+    var attributeStripper = new RegExp(' ' + badAttributes[i] + '="(.*?)"','gi');
+    output = output.replace(attributeStripper, '');
+  }
+
+  return output;
+}
+
+function getTags(htmlString){
+  var tmpTag = document.createElement("div");
+  tmpTag.innerHTML = htmlString;
+
+  var all = tmpTag.getElementsByTagName("*");
+  var goodTags = ['DIV', 'P', 'B', 'I', 'U', 'BR'];
+  var tags = [];
+
+  for (var i = 0, max = all.length; i < max; i++) {
+    var tagname = all[i].tagName;
+
+    if (tags.indexOf(tagname) == -1 && !goodTags.includes(tagname)) {
+      tags.push(tagname);
+    }
+  }
+
+  return tags
+}

--- a/app/assets/javascripts/views/descriptive_exams/show.js
+++ b/app/assets/javascripts/views/descriptive_exams/show.js
@@ -1,0 +1,3 @@
+$(function () {
+  createSummerNote("textarea[id^=descriptive_exam_students_attributes_]", { disabled: true })
+});

--- a/app/assets/javascripts/views/descriptive_exams/student_fields.js
+++ b/app/assets/javascripts/views/descriptive_exams/student_fields.js
@@ -1,73 +1,9 @@
 $(function () {
   $('textarea[maxLength]').maxlength();
 
-  $("textarea[id^=descriptive_exam_students_attributes_]").summernote({
-    lang: 'pt-BR',
+  createSummerNote("textarea[id^=descriptive_exam_students_attributes_]", {
     toolbar: [
       ['font', ['bold', 'italic', 'underline', 'clear']],
-    ],
-    disableDragAndDrop : true,
-    callbacks : {
-      onPaste : function (event) {
-        var thisNote = $(this);
-        var updatePastedText = function(someNote){
-          var original = someNote.summernote('code');
-          var cleaned = CleanPastedHTML(original);
-
-          someNote.summernote('code', cleaned);
-        };
-
-        setTimeout(function () {
-          //the function is called after the text is really pasted.
-          updatePastedText(thisNote);
-      }, 10);
-      }
-    }
-  });
-
-  function CleanPastedHTML(input) {
-    // 1. remove line breaks / Mso classes
-    var stringStripper = /(\n|\r| class=(")?Mso[a-zA-Z]+(")?)/g;
-    var output = input.replace(stringStripper, ' ');
-    // 2. strip Word generated HTML comments
-    var commentSripper = new RegExp('<!--(.*?)-->','g');
-    var output = output.replace(commentSripper, '');
-    var tagStripper = new RegExp('<(/)*(meta|link|span|\\?xml:|st1:|o:|font)(.*?)>','gi');
-    // 3. remove tags leave content if any
-    output = output.replace(tagStripper, '');
-    // 4. Remove everything in between and including tags '<style(.)style(.)>'
-    var badTags = getTags(output)
-    // remove all tags except ['DIV', 'P', 'B', 'I', 'U', 'BR'];
-    for (var i=0; i< badTags.length; i++) {
-      tagStripper = new RegExp('<'+badTags[i]+'.*?'+badTags[i]+'(.*?)>', 'gi');
-      output = output.replace(tagStripper, '');
-    }
-    // 5. remove attributes ' style="..."'
-    var badAttributes = ['style', 'start'];
-    for (var i=0; i< badAttributes.length; i++) {
-      var attributeStripper = new RegExp(' ' + badAttributes[i] + '="(.*?)"','gi');
-      output = output.replace(attributeStripper, '');
-    }
-
-    return output;
-  }
-
-  function getTags(htmlString){
-    var tmpTag = document.createElement("div");
-    tmpTag.innerHTML = htmlString;
-
-    var all = tmpTag.getElementsByTagName("*");
-    var goodTags = ['DIV', 'P', 'B', 'I', 'U', 'BR'];
-    var tags = [];
-
-    for (var i = 0, max = all.length; i < max; i++) {
-      var tagname = all[i].tagName;
-
-      if (tags.indexOf(tagname) == -1 && !goodTags.includes(tagname)) {
-        tags.push(tagname);
-      }
-    }
-
-    return tags
-  }
+    ]
+  })
 });

--- a/app/assets/javascripts/views/discipline_teaching_plans/form.js.erb
+++ b/app/assets/javascripts/views/discipline_teaching_plans/form.js.erb
@@ -45,8 +45,24 @@ $(function() {
   };
 
   $grade.on('change', function() {
-    fetchDisciplines();
+    validateMulti();
   });
+
+  function validateMulti() {
+    $.ajax({
+      url: Routes.multi_grade_classrooms_pt_br_path({ format: 'json' }),
+      success: function(classroom_multi) {
+        if (classroom_multi) {
+          return
+        }
+
+        fetchDisciplines();
+      },
+      error: function() {
+        flashMessages.error('Ocorreu um erro ao validar se a turma é multisseriada');
+      }
+    });
+  }
 
   $schoolTermType.on('change', function() {
     updateSchoolTermInput($schoolTermType, $schoolTerm, $schoolTermContainer, flashMessages);

--- a/app/assets/javascripts/views/exam_record_report/form.js
+++ b/app/assets/javascripts/views/exam_record_report/form.js
@@ -4,7 +4,7 @@ $(document).ready(function() {
   let flashMessages = new FlashMessages(),
       redirect_link_report_card = Routes.teacher_report_cards_pt_br_path(),
       redirect_link_conceptual_exams = Routes.conceptual_exams_pt_br_path(),
-      redirect_link_descriptive_exams = Routes.conceptual_exams_pt_br_path(),
+      redirect_link_descriptive_exams = Routes.new_descriptive_exam_pt_br_path(),
       message = `O <b>Registros de avaliações numéricas</b> apresentará somente as notas lançadas nos diários de avaliação e recuperações numéricas. Para conferência de notas conceituais e/ou descritivas acessar, respectivamente, o <a href="${redirect_link_report_card}"><b>Boletim do professor</b></a> ou as telas de <a href="${redirect_link_conceptual_exams}"><b>Diário de avaliações conceituais</b></a> e <a href="${redirect_link_descriptive_exams}"><b>Avaliações descritivas</b></a>.`;
 
   flashMessages.info(message);

--- a/app/assets/javascripts/views/exam_record_report/form.js
+++ b/app/assets/javascripts/views/exam_record_report/form.js
@@ -1,0 +1,11 @@
+$(document).ready(function() {
+  'use strict';
+
+  let flashMessages = new FlashMessages(),
+      redirect_link_report_card = Routes.teacher_report_cards_pt_br_path(),
+      redirect_link_conceptual_exams = Routes.conceptual_exams_pt_br_path(),
+      redirect_link_descriptive_exams = Routes.conceptual_exams_pt_br_path(),
+      message = `O <b>Registros de avaliações numéricas</b> apresentará somente as notas lançadas nos diários de avaliação e recuperações numéricas. Para conferência de notas conceituais e/ou descritivas acessar, respectivamente, o <a href="${redirect_link_report_card}"><b>Boletim do professor</b></a> ou as telas de <a href="${redirect_link_conceptual_exams}"><b>Diário de avaliações conceituais</b></a> e <a href="${redirect_link_descriptive_exams}"><b>Avaliações descritivas</b></a>.`;
+
+  flashMessages.info(message);
+});

--- a/app/assets/javascripts/views/lessons_boards/new.js
+++ b/app/assets/javascripts/views/lessons_boards/new.js
@@ -315,9 +315,17 @@ $(function () {
       });
 
       $("input[id*='_teacher_discipline_classroom_id']").each(function (index, teachers) {
-        $(teachers).select2({ data: teachers_to_select, escapeMarkup: function(data) { return data; }})
+        $(teachers).select2({ data: teachers_to_select, escapeMarkup, formatResult })
       })
     }
+  }
+
+  function escapeMarkup(data) {
+    return data;
+  }
+
+  function formatResult(state) {
+    return state.name;
   }
 
   function handleFetchTeachersFromTheClassroomError() {

--- a/app/assets/javascripts/views/lessons_boards/new.js
+++ b/app/assets/javascripts/views/lessons_boards/new.js
@@ -46,7 +46,27 @@ $(function () {
     }
 
     period_div.show();
+
+    populateClassroomGradeId();
   })
+
+  function populateClassroomGradeId() {
+    let grade_id = $('#lessons_board_grade').select2('val');
+    let classroom_id = $('#lessons_board_classroom_id').select2('val');
+
+    $.ajax({
+      url: Routes.classroom_grade_lessons_boards_pt_br_path({
+        grade_id: grade_id,
+        classroom_id: classroom_id,
+      }),
+      success: function(data) {
+        $('#lessons_board_classrooms_grade_id').val(data)
+      },
+      error: function() {
+        flashMessages.error('Ocorreu um erro ao buscar a série vinculada a turma.');
+      }
+    });
+  }
 
   $('#lessons_board_period').on('change', function() {
     errors = {};

--- a/app/assets/stylesheets/resources/lessons_boards.css
+++ b/app/assets/stylesheets/resources/lessons_boards.css
@@ -28,6 +28,8 @@
   text-overflow: clip !important;
   overflow-y: hidden;
   padding-right: 15px;
+  padding-bottom: 4px;
+  padding-top: 4px;
 }
 
 .select2-result-label {
@@ -36,20 +38,73 @@
 
 
 @media screen and (max-width: 768px) {
-.table_lessons {
-  overflow-x: auto;
+  .table_lessons {
+    overflow-x: auto;
+    width: 100%;
+    table-layout: auto;
+  }
+
+  .table_lessons_td {
+    width: 60%;
+    table-layout: fixed;
+  }
+
+  .table_lessons_td_select {
+    min-width: 160px
+  }
+}
+
+.flex-between {
+  display: flex;
+  justify-content: flex-start;
+  flex-direction: column;
   width: 100%;
-  table-layout: auto;
 }
 
-.table_lessons_td {
-  width: 60%;
-  table-layout: fixed;
+.flex-teacher {
+  margin-bottom: 4px;
+  display: flex;
+  align-items: center;
 }
 
-.table_lessons_td_select {
-  min-width: 160px
+.flex-teacher > div {
+  font-size: 11px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
 }
+
+.flex-discipline {
+  display:flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.flex-discipline-span {
+  color: white;
+  padding: 3px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+@media screen and (max-width: 1366px) {
+  .flex-between {
+    flex-direction: column;
+  }
+
+  .flex-discipline {
+    justify-content: flex-start;
+    width: 100%;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+
+  .flex-discipline-span {
+    white-space: normal;
+  }
 }
 
 

--- a/app/assets/stylesheets/resources/role_selector.css
+++ b/app/assets/stylesheets/resources/role_selector.css
@@ -61,6 +61,12 @@
   margin-left: 8px;
 }
 
+@media (max-width: 318px) {
+  .pull-right {
+    display: none;
+  }
+}
+
 .user-info img {
   border-radius: 4px;
   display: block;

--- a/app/controllers/absence_justification_report_controller.rb
+++ b/app/controllers/absence_justification_report_controller.rb
@@ -1,5 +1,5 @@
 class AbsenceJustificationReportController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
 
   def form

--- a/app/controllers/absence_justifications_controller.rb
+++ b/app/controllers/absence_justifications_controller.rb
@@ -1,5 +1,6 @@
 class AbsenceJustificationsController < ApplicationController
   before_action :require_current_teacher
+  before_action :require_current_classroom
 
   has_scope :page, default: 1
   has_scope :per, default: 10

--- a/app/controllers/api/v2/content_records_controller.rb
+++ b/app/controllers/api/v2/content_records_controller.rb
@@ -7,13 +7,13 @@ module Api
         return unless params[:teacher_id]
 
         @unities = Unity.by_teacher(params[:teacher_id]).ordered.uniq
-        @number_of_days = params[:number_of_days] || 90
+        @number_of_days = params[:number_of_days].to_i || 90
 
         @content_records = ContentRecord.by_unity_id(@unities.map(&:id))
                                         .by_teacher_id(params[:teacher_id])
                                         .joins(:discipline_content_record)
                                         .fromLastDays(@number_of_days)
-                                        .includes(classroom: [:unity, [classrooms_grades: :grade]])
+                                        .includes(classroom: [:unity, classrooms_grades: :grade])
       end
 
       def lesson_plans
@@ -23,7 +23,7 @@ module Api
         @lesson_plans = LessonPlan.by_unity_id(@unities.map(&:id))
                                   .by_teacher_id(params[:teacher_id])
                                   .fromLastDays(@number_of_days)
-                                  .includes(classroom: [:unity, [classrooms_grades: :grade]])
+                                  .includes(classroom: [:unity, classrooms_grades: :grade])
                                   .ordered
       end
 

--- a/app/controllers/api/v2/content_records_controller.rb
+++ b/app/controllers/api/v2/content_records_controller.rb
@@ -13,7 +13,7 @@ module Api
                                         .by_teacher_id(params[:teacher_id])
                                         .joins(:discipline_content_record)
                                         .fromLastDays(@number_of_days)
-                                        .includes(classroom: [:unity, :grade])
+                                        .includes(classroom: [:unity, [classrooms_grades: :grade]])
       end
 
       def lesson_plans
@@ -23,7 +23,7 @@ module Api
         @lesson_plans = LessonPlan.by_unity_id(@unities.map(&:id))
                                   .by_teacher_id(params[:teacher_id])
                                   .fromLastDays(@number_of_days)
-                                  .includes(classroom: [:unity, :grade])
+                                  .includes(classroom: [:unity, [classrooms_grades: :grade]])
                                   .ordered
       end
 

--- a/app/controllers/api/v2/exam_rules_controller.rb
+++ b/app/controllers/api/v2/exam_rules_controller.rb
@@ -4,7 +4,7 @@ module Api
       respond_to :json
 
       def index
-        exam_rule = classroom.exam_rule || ExamRule.new
+        exam_rule = classroom.first_exam_rule || ExamRule.new
         absence_type_definer = FrequencyTypeDefiner.new(classroom, teacher, year: classroom.year)
         absence_type_definer.define!
         exam_rule.allow_frequency_by_discipline =

--- a/app/controllers/api/v2/teacher_unities_controller.rb
+++ b/app/controllers/api/v2/teacher_unities_controller.rb
@@ -11,8 +11,6 @@ module Api
                         .by_teacher_with_school_calendar_year
                         .ordered
                         .uniq
-
-        @unities
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -241,26 +241,38 @@ class ApplicationController < ActionController::Base
     ).valid?
   end
 
-  def teacher_discipline_score_type
-    teacher_discipline_score_type_by_exam_rule(current_user_classroom.exam_rule)
+  def teacher_discipline_score_types
+    score_types = []
+
+    current_user_classroom.classrooms_grades.each do |classroom_grade|
+      score_types << teacher_discipline_score_type_by_exam_rule(classroom_grade.exam_rule)
+    end
+
+    score_types
   end
 
   def current_user_is_employee_or_administrator?
     current_user.assumed_teacher_id.blank? && current_user.current_role_is_admin_or_employee?
   end
 
-  def teacher_differentiated_discipline_score_type
-    exam_rule = current_user_classroom.exam_rule
+  def teacher_differentiated_discipline_score_types
+    score_types = []
 
-    return if exam_rule.blank?
+    current_user_classroom.classrooms_grades.each do |classroom_grade|
+      exam_rule = classroom_grade.exam_rule
 
-    differentiated_exam_rule = exam_rule.differentiated_exam_rule
+      next if exam_rule.blank?
 
-    if differentiated_exam_rule.blank? || !current_user_classroom.has_differentiated_students?
-      return teacher_discipline_score_type_by_exam_rule(exam_rule)
+      differentiated_exam_rule = exam_rule.differentiated_exam_rule
+
+      if differentiated_exam_rule.blank? || !classroom_grade.classroom.has_differentiated_students?
+        score_types << teacher_discipline_score_type_by_exam_rule(exam_rule)
+      end
+
+      score_types << teacher_discipline_score_type_by_exam_rule(differentiated_exam_rule)
     end
 
-    teacher_discipline_score_type_by_exam_rule(differentiated_exam_rule)
+    score_types
   end
 
   def teacher_discipline_score_type_by_exam_rule(exam_rule)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -212,7 +212,7 @@ class ApplicationController < ActionController::Base
     redirect_to root_path
   end
 
-  def require_current_clasroom
+  def require_current_classroom
     return if current_user_classroom
 
     flash[:alert] = t('errors.general.require_current_classroom')

--- a/app/controllers/attendance_record_report_controller.rb
+++ b/app/controllers/attendance_record_report_controller.rb
@@ -1,5 +1,5 @@
 class AttendanceRecordReportController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
 
   def form

--- a/app/controllers/avaliation_recovery_diary_records_controller.rb
+++ b/app/controllers/avaliation_recovery_diary_records_controller.rb
@@ -2,7 +2,7 @@ class AvaliationRecoveryDiaryRecordsController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/controllers/avaliation_recovery_diary_records_controller.rb
+++ b/app/controllers/avaliation_recovery_diary_records_controller.rb
@@ -206,6 +206,7 @@ class AvaliationRecoveryDiaryRecordsController < ApplicationController
     return unless @avaliation_recovery_diary_record.recovery_diary_record.recorded_at
 
     StudentEnrollmentsList.new(classroom: @avaliation_recovery_diary_record.recovery_diary_record.classroom,
+                               grade: @avaliation_recovery_diary_record.avaliation.grade_ids,
                                discipline: @avaliation_recovery_diary_record.recovery_diary_record.discipline,
                                score_type: StudentEnrollmentScoreTypeFilters::NUMERIC,
                                date: @avaliation_recovery_diary_record.recovery_diary_record.recorded_at,

--- a/app/controllers/avaliations_controller.rb
+++ b/app/controllers/avaliations_controller.rb
@@ -44,6 +44,7 @@ class AvaliationsController < ApplicationController
   def new
     return if test_settings_redirect
     return if score_types_redirect
+    return if not_allow_numerical_exam
 
     @avaliation = resource
     @avaliation.school_calendar = current_school_calendar
@@ -55,6 +56,7 @@ class AvaliationsController < ApplicationController
   def multiple_classrooms
     return if test_settings_redirect
     return if score_types_redirect
+    return if not_allow_numerical_exam
 
     @avaliation_multiple_creator_form = AvaliationMultipleCreatorForm.new.localized
     @avaliation_multiple_creator_form.school_calendar_id = current_school_calendar.id
@@ -300,6 +302,14 @@ class AvaliationsController < ApplicationController
     return if available_score_types.any? { |discipline_score_type| discipline_score_type == ScoreTypes::NUMERIC }
 
     redirect_to avaliations_path, alert: t('avaliation.numeric_exam_absence')
+  end
+
+  def not_allow_numerical_exam
+    grades_by_numerical_exam = current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC).map(&:grade)
+
+    return if grades_by_numerical_exam.present?
+
+    redirect_to avaliations_path, alert: t('avaliation.grades_not_allow_numeric_exam')
   end
 
   def grades

--- a/app/controllers/avaliations_controller.rb
+++ b/app/controllers/avaliations_controller.rb
@@ -4,7 +4,7 @@ class AvaliationsController < ApplicationController
 
   respond_to :html, :js, :json
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher, except: [:search]
   before_action :set_number_of_classes, only: [
     :new, :create, :edit, :update, :multiple_classrooms, :create_multiple_classrooms

--- a/app/controllers/avaliations_controller.rb
+++ b/app/controllers/avaliations_controller.rb
@@ -53,7 +53,6 @@ class AvaliationsController < ApplicationController
   end
 
   def multiple_classrooms
-    return if current_user_classroom.multi_grade?
     return if test_settings_redirect
     return if score_types_redirect
 
@@ -116,6 +115,15 @@ class AvaliationsController < ApplicationController
     @avaliation.current_user = current_user
 
     authorize @avaliation
+
+    if resource.grade_ids.empty?
+      flash[:error] = 'Série não pode ficar em branco'
+      test_settings
+
+      return render :edit
+    else
+      flash.clear
+    end
 
     if resource.save
       respond_to_save

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -23,6 +23,10 @@ class ClassroomsController < ApplicationController
     @classrooms = @classrooms.ordered.uniq
   end
 
+  def multi_grade
+    render json: current_user_classroom.multi_grade?
+  end
+
   def show
     return unless teacher_id = current_teacher.try(:id)
     id = params[:id]

--- a/app/controllers/complementary_exam_settings_controller.rb
+++ b/app/controllers/complementary_exam_settings_controller.rb
@@ -77,7 +77,7 @@ class ComplementaryExamSettingsController < ApplicationController
 
   def grades
     @grades ||= Grade.includes(:course)
-                     .joins(classrooms: :exam_rule)
+                     .joins(classrooms_grades: :exam_rule)
                      .merge(ExamRule.where(score_type: ScoreTypes::NUMERIC))
                      .ordered
                      .uniq

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -6,6 +6,7 @@ class ConceptualExamsController < ApplicationController
   before_action :require_current_teacher
   before_action :adjusted_period
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
+  before_action :view_data, only: [:edit, :show]
 
   def index
     step_id = (params[:filter] || []).delete(:by_step)
@@ -93,21 +94,6 @@ class ConceptualExamsController < ApplicationController
     render :new
   end
 
-  def edit
-    @conceptual_exam = ConceptualExam.find(params[:id]).localized
-    @conceptual_exam.unity_id = @conceptual_exam.classroom.unity_id
-    @conceptual_exam.step_id = find_step_id
-
-    authorize @conceptual_exam
-
-    fetch_collections
-
-    add_missing_disciplines
-    mark_not_assigned_disciplines_for_destruction
-    mark_not_existing_disciplines_as_invisible
-    mark_exempted_disciplines
-  end
-
   def update
     @conceptual_exam = ConceptualExam.find(params[:id])
     @conceptual_exam.assign_attributes(resource_params)
@@ -174,6 +160,20 @@ class ConceptualExamsController < ApplicationController
   end
 
   private
+
+  def view_data
+    @conceptual_exam = ConceptualExam.find(params[:id]).localized
+    @conceptual_exam.unity_id = @conceptual_exam.classroom.unity_id
+    @conceptual_exam.step_id = find_step_id
+
+    authorize @conceptual_exam
+
+    fetch_collections
+    add_missing_disciplines
+    mark_not_assigned_disciplines_for_destruction
+    mark_not_existing_disciplines_as_invisible
+    mark_exempted_disciplines
+  end
 
   def resource_params
     params.require(:conceptual_exam).permit(

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -31,7 +31,7 @@ class ConceptualExamsController < ApplicationController
   end
 
   def new
-    discipline_score_types = [teacher_differentiated_discipline_score_type, teacher_discipline_score_type]
+    discipline_score_types = (teacher_differentiated_discipline_score_types + teacher_discipline_score_types).uniq
 
     not_concept_score = discipline_score_types.none? { |discipline_score_type|
       discipline_score_type == ScoreTypes::CONCEPT

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -136,11 +136,9 @@ class ConceptualExamsController < ApplicationController
     authorize @conceptual_exam
 
     if @conceptual_exam.valid?
-      current_teacher_disciplines = Discipline.by_teacher_and_classroom(current_teacher.id, current_user_classroom.id)
-      values_to_destroy = ConceptualExamValue.by_conceptual_exam_id(@conceptual_exam.id)
-                                             .by_discipline_id(current_teacher_disciplines)
+      ConceptualExamValue.by_conceptual_exam_id(@conceptual_exam.id)
+                         .destroy_all
 
-      values_to_destroy.each(&:destroy)
       @conceptual_exam.destroy unless ConceptualExamValue.by_conceptual_exam_id(@conceptual_exam.id).any?
     end
 

--- a/app/controllers/conceptual_exams_controller.rb
+++ b/app/controllers/conceptual_exams_controller.rb
@@ -2,7 +2,7 @@ class ConceptualExamsController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :adjusted_period
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]

--- a/app/controllers/daily_frequencies_controller.rb
+++ b/app/controllers/daily_frequencies_controller.rb
@@ -25,9 +25,9 @@ class DailyFrequenciesController < ApplicationController
     @period = params[:daily_frequency][:period]
 
     if @daily_frequency.valid?
-      frequency_type = current_frequency_type(@daily_frequency)
+      @frequency_type = current_frequency_type(@daily_frequency)
 
-      return if frequency_type == FrequencyTypes::BY_DISCIPLINE && !(validate_class_numbers && validate_discipline)
+      return if @frequency_type == FrequencyTypes::BY_DISCIPLINE && !(validate_class_numbers && validate_discipline)
 
       redirect_to edit_multiple_daily_frequencies_path(
         daily_frequency: daily_frequency_params,
@@ -330,6 +330,7 @@ class DailyFrequenciesController < ApplicationController
   def fetch_student_enrollments
     StudentEnrollmentsList.new(
       classroom: @daily_frequency.classroom,
+      grade: discipline_classroom_grade_ids,
       discipline: @daily_frequency.discipline,
       date: @daily_frequency.frequency_date,
       search_type: :by_date,
@@ -393,5 +394,23 @@ class DailyFrequenciesController < ApplicationController
     return if current_user.current_classroom_id == params[:daily_frequency][:classroom_id].to_i
 
     redirect_to new_daily_frequency_path
+  end
+
+  def discipline_classroom_grade_ids
+    classroom_grade_ids = ClassroomsGrade.by_classroom_id(@daily_frequency.classroom.id).pluck(:grade_id)
+    school_calendar = StepsFetcher.new(@daily_frequency.classroom).school_calendar
+
+    if @frequency_type == FrequencyTypes::BY_DISCIPLINE
+      SchoolCalendarDisciplineGrade.where(
+        grade_id: classroom_grade_ids,
+        school_calendar_id: school_calendar.id,
+        discipline_id: @daily_frequency.discipline.id
+      ).pluck(:grade_id)
+    else
+      SchoolCalendarDisciplineGrade.where(
+        grade_id: classroom_grade_ids,
+        school_calendar_id: school_calendar.id,
+      ).pluck(:grade_id)
+    end
   end
 end

--- a/app/controllers/daily_frequencies_controller.rb
+++ b/app/controllers/daily_frequencies_controller.rb
@@ -1,5 +1,5 @@
 class DailyFrequenciesController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_teacher
   before_action :set_number_of_classes, only: [:new, :create, :edit_multiple]
   before_action :require_allow_to_modify_prev_years, only: [:create, :destroy_multiple]

--- a/app/controllers/daily_frequencies_in_batchs_controller.rb
+++ b/app/controllers/daily_frequencies_in_batchs_controller.rb
@@ -126,8 +126,9 @@ class DailyFrequenciesInBatchsController < ApplicationController
       student = student_enrollment.student
       student_ids << student.id
       type_of_teaching = student_enrollment.student_enrollment_classrooms
-                                           .where(classroom_id: current_user_classroom.id)
-                                           .last.type_of_teaching
+                                           .by_classroom(current_user_classroom.id)
+                                           .last
+                                           .type_of_teaching
 
       next if student.blank?
 

--- a/app/controllers/daily_frequencies_in_batchs_controller.rb
+++ b/app/controllers/daily_frequencies_in_batchs_controller.rb
@@ -1,5 +1,5 @@
 class DailyFrequenciesInBatchsController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_teacher
   before_action :require_allocation_on_lessons_board
   before_action :set_number_of_classes, only: [:new, :create, :create_or_update_multiple]

--- a/app/controllers/daily_note_students_controller.rb
+++ b/app/controllers/daily_note_students_controller.rb
@@ -95,9 +95,8 @@ class DailyNoteStudentsController < ApplicationController
           in_active_search: ActiveSearch.new.in_active_search?(student_enrollment.id, daily_note.avaliation.test_date)
         }
       end
-
-      respond_with @students and return
     end
+    respond_with @students
   end
 
   private

--- a/app/controllers/daily_note_students_controller.rb
+++ b/app/controllers/daily_note_students_controller.rb
@@ -38,62 +38,65 @@ class DailyNoteStudentsController < ApplicationController
     @normal_students = []
     @dependence_students = []
 
-    if @daily_note_students.empty?
-      respond_with @students
-    else
-      daily_note = @daily_note_students.first.daily_note
-      date_for_search = params[:search][:recorded_at].to_date
+    respond_with @students if @daily_note_students.empty?
 
-      student_enrollments = fetch_student_enrollments(daily_note.classroom, daily_note.discipline, date_for_search)
+    daily_note = @daily_note_students.first.daily_note
+    date_for_search = params[:search][:recorded_at].to_date
 
-      normal_sequence = 0
-      dependence_sequence = 0
+    student_enrollments = fetch_student_enrollments(
+      daily_note.classroom,
+      daily_note.avaliation,
+      daily_note.discipline,
+      date_for_search
+    )
 
-      student_enrollments.each do |student_enrollment|
-        student = Student.find_by(id: student_enrollment.student_id)
-        next unless student
+    normal_sequence = 0
+    dependence_sequence = 0
 
-        note_student = @daily_note_students.where(student_id: student.id).first ||
-          DailyNoteStudent.new(student: student)
+    student_enrollments.each do |student_enrollment|
+      student = Student.find_by(id: student_enrollment.student_id)
+      next unless student
 
-        note_student.dependence = student_has_dependence?(student_enrollment, daily_note.discipline)
-        note_student.active = student_active_on_date?(student_enrollment, daily_note.classroom, date_for_search)
-        note_student.exempted_from_discipline = student_exempted_from_discipline?(student_enrollment, daily_note)
+      note_student = @daily_note_students.where(student_id: student.id).first ||
+                     DailyNoteStudent.new(student: student)
 
-        if note_student.dependence
-          @dependence_students << note_student
+      note_student.dependence = student_has_dependence?(student_enrollment, daily_note.discipline)
+      note_student.active = student_active_on_date?(student_enrollment, daily_note.classroom, date_for_search)
+      note_student.exempted_from_discipline = student_exempted_from_discipline?(student_enrollment, daily_note)
 
-          dependence_sequence += 1
+      if note_student.dependence
+        @dependence_students << note_student
 
-          @students << {
-            sequence: dependence_sequence,
-            id: note_student.student_id,
-            name: note_student.student.to_s,
-            note: note_student.note,
-            dependence: note_student.dependence,
-            exempted_from_discipline: note_student.exempted_from_discipline,
-            active: note_student.active,
-            in_active_search: ActiveSearch.new.in_active_search?(student_enrollment.id, daily_note.avaliation.test_date)
-          }
-        else
-          @normal_students << note_student
+        dependence_sequence += 1
 
-          normal_sequence += 1
+        @students << {
+          sequence: dependence_sequence,
+          id: note_student.student_id,
+          name: note_student.student.to_s,
+          note: note_student.note,
+          dependence: note_student.dependence,
+          exempted_from_discipline: note_student.exempted_from_discipline,
+          active: note_student.active,
+          in_active_search: ActiveSearch.new.in_active_search?(student_enrollment.id, daily_note.avaliation.test_date)
+        }
+      else
+        @normal_students << note_student
 
-          @students << {
-            sequence: normal_sequence,
-            id: note_student.student_id,
-            name: note_student.student.to_s,
-            note: note_student.note,
-            dependence: note_student.dependence,
-            exempted_from_discipline: note_student.exempted_from_discipline,
-            active: note_student.active,
-            in_active_search: ActiveSearch.new.in_active_search?(student_enrollment.id, daily_note.avaliation.test_date)
-          }
-        end
+        normal_sequence += 1
+
+        @students << {
+          sequence: normal_sequence,
+          id: note_student.student_id,
+          name: note_student.student.to_s,
+          note: note_student.note,
+          dependence: note_student.dependence,
+          exempted_from_discipline: note_student.exempted_from_discipline,
+          active: note_student.active,
+          in_active_search: ActiveSearch.new.in_active_search?(student_enrollment.id, daily_note.avaliation.test_date)
+        }
       end
 
-      respond_with @students
+      respond_with @students and return
     end
   end
 
@@ -112,9 +115,10 @@ class DailyNoteStudentsController < ApplicationController
                      .any?
   end
 
-  def fetch_student_enrollments(classroom, discipline, date)
+  def fetch_student_enrollments(classroom, avaliation, discipline, date)
     StudentEnrollmentsList.new(
       classroom: classroom,
+      grade: avaliation.grade_ids,
       discipline: discipline,
       date: date,
       score_type: StudentEnrollmentScoreTypeFilters::NUMERIC,

--- a/app/controllers/daily_notes_controller.rb
+++ b/app/controllers/daily_notes_controller.rb
@@ -172,6 +172,7 @@ class DailyNotesController < ApplicationController
 
   def fetch_student_enrollments
     StudentEnrollmentsList.new(classroom: @daily_note.classroom,
+                               grade: @daily_note.avaliation.grade_ids,
                                discipline: @daily_note.discipline,
                                date: @daily_note.avaliation.test_date,
                                score_type: StudentEnrollmentScoreTypeFilters::NUMERIC,

--- a/app/controllers/daily_notes_controller.rb
+++ b/app/controllers/daily_notes_controller.rb
@@ -2,7 +2,7 @@ class DailyNotesController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/controllers/descriptive_exams_controller.rb
+++ b/app/controllers/descriptive_exams_controller.rb
@@ -75,7 +75,7 @@ class DescriptiveExamsController < ApplicationController
                                          .by_discipline_id(discipline_id)
                                          .by_step_id(current_user_classroom, step_id)
                                          .first
-                                         .id
+                                         &.id
 
     render json: descriptive_exam_id
   end

--- a/app/controllers/descriptive_exams_controller.rb
+++ b/app/controllers/descriptive_exams_controller.rb
@@ -64,7 +64,7 @@ class DescriptiveExamsController < ApplicationController
   end
 
   def find
-    return if params[:step_id].blank? || params[:opinion_type].blank?
+    return render json: nil if params[:step_id].blank? || params[:opinion_type].blank?
 
     discipline_id = params[:discipline_id].blank? ? nil : params[:discipline_id].to_i
     step_id = opinion_type_by_year?(params[:opinion_type].to_i) ? nil : params[:step_id].to_i

--- a/app/controllers/descriptive_exams_controller.rb
+++ b/app/controllers/descriptive_exams_controller.rb
@@ -1,5 +1,5 @@
 class DescriptiveExamsController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_teacher
   before_action :adjusted_period, only: [:edit, :update]
   before_action :require_allow_to_modify_prev_years, only: :update

--- a/app/controllers/descriptive_exams_controller.rb
+++ b/app/controllers/descriptive_exams_controller.rb
@@ -216,7 +216,7 @@ class DescriptiveExamsController < ApplicationController
     differentiated_opinion_type = exam_rules.find { |exam_rule|
       exam_rule.differentiated_exam_rule&.allow_descriptive_exam? &&
         exam_rule.differentiated_exam_rule.opinion_type != descriptive_exam_opinion_type
-    }&.opinion_type
+    }&.differentiated_exam_rule&.opinion_type
 
     if differentiated_opinion_type.present?
       @opinion_types << OpenStruct.new(

--- a/app/controllers/discipline_lesson_plans_controller.rb
+++ b/app/controllers/discipline_lesson_plans_controller.rb
@@ -2,7 +2,7 @@ class DisciplineLessonPlansController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom, only: [:new, :edit, :create, :update]
+  before_action :require_current_classroom, only: [:new, :edit, :create, :update]
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy, :clone]
 

--- a/app/controllers/discipline_teaching_plans_controller.rb
+++ b/app/controllers/discipline_teaching_plans_controller.rb
@@ -20,7 +20,7 @@ class DisciplineTeachingPlansController < ApplicationController
     )
 
     unless current_user_is_employee_or_administrator?
-      @discipline_teaching_plans = @discipline_teaching_plans.by_grade(current_user_classroom.try(:grade))
+      @discipline_teaching_plans = @discipline_teaching_plans.by_grade(current_user_classroom.first_grade.id)
                                                              .by_discipline(current_user_discipline)
     end
 

--- a/app/controllers/discipline_teaching_plans_controller.rb
+++ b/app/controllers/discipline_teaching_plans_controller.rb
@@ -6,6 +6,7 @@ class DisciplineTeachingPlansController < ApplicationController
   before_action :require_current_teacher, unless: :current_user_is_employee_or_administrator?
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
   before_action :yearly_term_type_id, only: [:show, :edit, :new]
+  before_action :require_current_classroom, only: [:index]
 
   def index
     params[:filter] ||= {}
@@ -20,7 +21,7 @@ class DisciplineTeachingPlansController < ApplicationController
     )
 
     unless current_user_is_employee_or_administrator?
-      @discipline_teaching_plans = @discipline_teaching_plans.by_grade(current_user_classroom.first_grade.id)
+      @discipline_teaching_plans = @discipline_teaching_plans.by_grade(current_user_classroom.grades.pluck(:id))
                                                              .by_discipline(current_user_discipline)
     end
 

--- a/app/controllers/exam_record_report_controller.rb
+++ b/app/controllers/exam_record_report_controller.rb
@@ -1,5 +1,5 @@
 class ExamRecordReportController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
 
   def form

--- a/app/controllers/exam_rules_controller.rb
+++ b/app/controllers/exam_rules_controller.rb
@@ -3,17 +3,17 @@ class ExamRulesController < ApplicationController
     classroom = Classroom.find_by(id: params[:classroom_id])
     student = Student.find_by(id: params[:student_id])
 
-    return if classroom.blank?
+    return render json: nil if classroom.blank?
 
-    classroom_grades = ClassroomsGrade.by_classroom_id(classroom.id)
+    classroom_grades = classroom.classrooms_grades
     classroom_grades = classroom_grades.by_student_id(student.id) if student.present?
     classroom_grade = classroom_grades&.first
 
-    return if classroom_grade.blank?
+    return render json: nil if classroom_grade.blank?
 
     @exam_rule = classroom_grade&.exam_rule
 
-    return if @exam_rule.blank?
+    return render json: nil if @exam_rule.blank?
 
     @exam_rule = @exam_rule.differentiated_exam_rule || @exam_rule if student.try(:uses_differentiated_exam_rule)
 

--- a/app/controllers/exam_rules_controller.rb
+++ b/app/controllers/exam_rules_controller.rb
@@ -1,12 +1,25 @@
 class ExamRulesController < ApplicationController
   def index
-    classroom = Classroom.find(params[:classroom_id])
-    student = Student.find_by_id(params[:student_id])
+    classroom = Classroom.find_by(id: params[:classroom_id])
+    student = Student.find_by(id: params[:student_id])
 
-    @exam_rule = classroom.exam_rule
+    return if classroom.blank?
+
+    classroom_grades = ClassroomsGrade.by_classroom_id(classroom.id)
+    classroom_grades = classroom_grades.by_student_id(student.id) if student.present?
+    classroom_grade = classroom_grades&.first
+
+    return if classroom_grade.blank?
+
+    @exam_rule = classroom_grade&.exam_rule
+
+    return if @exam_rule.blank?
+
     @exam_rule = @exam_rule.differentiated_exam_rule || @exam_rule if student.try(:uses_differentiated_exam_rule)
+
     absence_type_definer = FrequencyTypeDefiner.new(classroom, current_teacher, @exam_rule, year: classroom.year)
     absence_type_definer.define!
+
     @exam_rule&.allow_frequency_by_discipline = (absence_type_definer.frequency_type == FrequencyTypes::BY_DISCIPLINE)
 
     render json: @exam_rule

--- a/app/controllers/final_recovery_diary_records_controller.rb
+++ b/app/controllers/final_recovery_diary_records_controller.rb
@@ -2,7 +2,7 @@ class FinalRecoveryDiaryRecordsController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/controllers/ieducar_api_exam_postings_controller.rb
+++ b/app/controllers/ieducar_api_exam_postings_controller.rb
@@ -1,5 +1,5 @@
 class IeducarApiExamPostingsController < ApplicationController
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_current_teacher_discipline_classrooms
   before_action :require_current_posting_step

--- a/app/controllers/infrequency_trackings_controller.rb
+++ b/app/controllers/infrequency_trackings_controller.rb
@@ -7,11 +7,11 @@ class InfrequencyTrackingsController < ApplicationController
       InfrequencyTracking.includes(
         :mvw_infrequency_tracking_classroom,
         :student,
-        classroom: [:unity, :grade]
+        classroom: [:unity, classrooms_grades: :grade]
       ).joins(
         :mvw_infrequency_tracking_classroom,
         :student,
-        classroom: [:unity, :grade]
+        classroom: [:unity, classrooms_grades: :grade]
       ).merge(classrooms).ordered
     )
 

--- a/app/controllers/knowledge_area_lesson_plans_controller.rb
+++ b/app/controllers/knowledge_area_lesson_plans_controller.rb
@@ -2,7 +2,7 @@ class KnowledgeAreaLessonPlansController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom, only: [:new, :edit, :create, :update]
+  before_action :require_current_classroom, only: [:new, :edit, :create, :update]
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy, :clone]
 

--- a/app/controllers/knowledge_area_teaching_plans_controller.rb
+++ b/app/controllers/knowledge_area_teaching_plans_controller.rb
@@ -6,6 +6,7 @@ class KnowledgeAreaTeachingPlansController < ApplicationController
   before_action :require_current_teacher, unless: :current_user_is_employee_or_administrator?
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
   before_action :yearly_term_type_id, only: [:show, :edit, :new]
+  before_action :require_current_classroom, only: [:index]
 
   def index
     params[:filter] ||= {}
@@ -21,7 +22,7 @@ class KnowledgeAreaTeachingPlansController < ApplicationController
 
     unless current_user_is_employee_or_administrator?
       @knowledge_area_teaching_plans =
-        @knowledge_area_teaching_plans.by_grade(current_user_classroom.first_grade.id)
+        @knowledge_area_teaching_plans.by_grade(current_user_classroom.grades.pluck(:id))
     end
 
     if author_type.present?

--- a/app/controllers/knowledge_area_teaching_plans_controller.rb
+++ b/app/controllers/knowledge_area_teaching_plans_controller.rb
@@ -21,7 +21,7 @@ class KnowledgeAreaTeachingPlansController < ApplicationController
 
     unless current_user_is_employee_or_administrator?
       @knowledge_area_teaching_plans =
-        @knowledge_area_teaching_plans.by_grade(current_user_classroom.try(:grade_id))
+        @knowledge_area_teaching_plans.by_grade(current_user_classroom.first_grade.id)
     end
 
     if author_type.present?

--- a/app/controllers/lessons_boards_controller.rb
+++ b/app/controllers/lessons_boards_controller.rb
@@ -260,10 +260,10 @@ class LessonsBoardsController < ApplicationController
                                 .each do |teacher_discipline_classroom|
         teachers_to_select2 << OpenStruct.new(
           id: teacher_discipline_classroom.id,
-          name: teacher_discipline_classroom.teacher.name.try(:strip) + ' - ' +
-            teacher_discipline_classroom.discipline,
-          text: teacher_discipline_classroom.teacher.name.try(:strip).to_s + ' - ' +
-            teacher_discipline_classroom.discipline
+          name: discipline_teacher_name(teacher_discipline_classroom.discipline,
+                                        teacher_discipline_classroom.teacher.name.try(:strip)),
+          text: discipline_teacher_name(teacher_discipline_classroom.discipline,
+                                        teacher_discipline_classroom.teacher.name.try(:strip))
         )
       end
     else
@@ -273,8 +273,10 @@ class LessonsBoardsController < ApplicationController
                                 .each do |teacher_discipline_classroom|
         teachers_to_select2 << OpenStruct.new(
           id: teacher_discipline_classroom.id,
-          name: discipline_teacher_name(teacher_discipline_classroom.discipline, teacher_discipline_classroom.teacher.name.try(:strip)),
-          text: discipline_teacher_name(teacher_discipline_classroom.discipline, teacher_discipline_classroom.teacher.name.try(:strip))
+          name: discipline_teacher_name(teacher_discipline_classroom.discipline,
+                                        teacher_discipline_classroom.teacher.name.try(:strip)),
+          text: discipline_teacher_name(teacher_discipline_classroom.discipline,
+                                        teacher_discipline_classroom.teacher.name.try(:strip))
         )
       end
     end

--- a/app/controllers/lessons_boards_controller.rb
+++ b/app/controllers/lessons_boards_controller.rb
@@ -57,7 +57,7 @@ class LessonsBoardsController < ApplicationController
   def destroy
     authorize resource
 
-    resource.destroy
+    resource.discard
 
     respond_with resource, location: lessons_boards_path
   end

--- a/app/controllers/lessons_boards_controller.rb
+++ b/app/controllers/lessons_boards_controller.rb
@@ -261,9 +261,9 @@ class LessonsBoardsController < ApplicationController
         teachers_to_select2 << OpenStruct.new(
           id: teacher_discipline_classroom.id,
           name: teacher_discipline_classroom.teacher.name.try(:strip) + ' - ' +
-            teacher_discipline_classroom.discipline.description.try(:strip),
+            teacher_discipline_classroom.discipline,
           text: teacher_discipline_classroom.teacher.name.try(:strip).to_s + ' - ' +
-            teacher_discipline_classroom.discipline.description.try(:strip)
+            teacher_discipline_classroom.discipline
         )
       end
     else
@@ -273,8 +273,8 @@ class LessonsBoardsController < ApplicationController
                                 .each do |teacher_discipline_classroom|
         teachers_to_select2 << OpenStruct.new(
           id: teacher_discipline_classroom.id,
-          name: discipline_teacher_name(teacher_discipline_classroom.discipline.description.try(:strip), teacher_discipline_classroom.teacher.name.try(:strip)),
-          text: discipline_teacher_name(teacher_discipline_classroom.discipline.description.try(:strip), teacher_discipline_classroom.teacher.name.try(:strip))
+          name: discipline_teacher_name(teacher_discipline_classroom.discipline, teacher_discipline_classroom.teacher.name.try(:strip)),
+          text: discipline_teacher_name(teacher_discipline_classroom.discipline, teacher_discipline_classroom.teacher.name.try(:strip))
         )
       end
     end
@@ -285,7 +285,16 @@ class LessonsBoardsController < ApplicationController
   end
 
   def discipline_teacher_name(discipline, teacher)
-    "#{teacher} - <b>#{discipline}</b>"
+    "<div class='flex-between'>
+       <div class='flex-teacher'>
+          <div>
+            #{teacher.upcase}
+          </div>
+       </div>
+       <div class='flex-discipline'>
+         <span class='flex-discipline-span' style='background-color: #{discipline.label_color};'>#{discipline.description.try(:strip)}</span>
+       </div>
+     </div>"
   end
 
   def classrooms_to_select2(grade_id, unity_id)

--- a/app/controllers/observation_diary_records_controller.rb
+++ b/app/controllers/observation_diary_records_controller.rb
@@ -2,7 +2,7 @@ class ObservationDiaryRecordsController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/controllers/school_term_recovery_diary_records_controller.rb
+++ b/app/controllers/school_term_recovery_diary_records_controller.rb
@@ -2,7 +2,7 @@ class SchoolTermRecoveryDiaryRecordsController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/controllers/teacher_report_cards_controller.rb
+++ b/app/controllers/teacher_report_cards_controller.rb
@@ -19,7 +19,7 @@ class TeacherReportCardsController < ApplicationController
       unity = current_unity
       discipline = Discipline.find(@teacher_report_card_form.discipline_id)
       classroom = Classroom.find(@teacher_report_card_form.classroom_id)
-      grade = classroom.grade
+      grade = Grade.find(@teacher_report_card_form.grade_id)
       course = grade.course
       year = current_school_calendar.year
 
@@ -65,9 +65,14 @@ class TeacherReportCardsController < ApplicationController
   end
   helper_method :disciplines
 
+  def grades
+    @grades ||= current_user_classroom.classrooms_grades.map(&:grade)
+  end
+  helper_method :grades
+
   def resource_params
     params.require(:teacher_report_card_form).permit(
-      :unity_id, :classroom_id, :discipline_id, :status
+      :unity_id, :classroom_id, :grade_id, :discipline_id, :status
     )
   end
 end

--- a/app/controllers/transfer_notes_controller.rb
+++ b/app/controllers/transfer_notes_controller.rb
@@ -2,7 +2,7 @@ class TransferNotesController < ApplicationController
   has_scope :page, default: 1
   has_scope :per, default: 10
 
-  before_action :require_current_clasroom
+  before_action :require_current_classroom
   before_action :require_current_teacher
   before_action :require_allow_to_modify_prev_years, only: [:create, :update, :destroy]
 

--- a/app/decorators/conceptual_exam_value_decorator.rb
+++ b/app/decorators/conceptual_exam_value_decorator.rb
@@ -3,7 +3,13 @@ class ConceptualExamValueDecorator
   include Decore::Proxy
 
   def data_for_select2
-    exam_rule = conceptual_exam.classroom.exam_rule
+    classroom_grade = ClassroomsGrade.by_student_id(conceptual_exam.student.id)
+                                     .by_classroom_id(conceptual_exam.classroom.id)
+                                     &.first
+
+    return if classroom_grade.blank?
+
+    exam_rule = classroom_grade&.exam_rule
 
     if conceptual_exam.student.try(:uses_differentiated_exam_rule)
       exam_rule = exam_rule.differentiated_exam_rule || exam_rule

--- a/app/enumerations/student_enrollment_status.rb
+++ b/app/enumerations/student_enrollment_status.rb
@@ -1,0 +1,16 @@
+class StudentEnrollmentStatus < EnumerateIt::Base
+  associate_values approved: 1,
+                   repproved: 2,
+                   studying: 3,
+                   transferred: 4,
+                   reclassified: 5,
+                   abandonment: 6,
+                   excepted_transferred_or_abandonment: 9,
+                   all: 10,
+                   approved_with_dependency: 12,
+                   approve_by_council: 13,
+                   disapproved_by_faults: 14,
+                   deceased: 15
+
+  sort_by :none
+end

--- a/app/forms/teacher_report_card_form.rb
+++ b/app/forms/teacher_report_card_form.rb
@@ -3,8 +3,9 @@ class TeacherReportCardForm
 
   attr_accessor :unity_id,
                 :classroom_id,
+                :grade_id,
                 :discipline_id,
                 :status
 
-  validates :unity_id, :classroom_id, :discipline_id, :status, presence: true
+  validates :unity_id, :classroom_id, :grade_id, :discipline_id, :status, presence: true
 end

--- a/app/helpers/avaliation_helper.rb
+++ b/app/helpers/avaliation_helper.rb
@@ -1,5 +1,4 @@
 module AvaliationHelper
-
   def show_avaliation_weight
     if @avaliation.test_setting.try(:arithmetic?)
       { class: 'hidden' }
@@ -8,4 +7,45 @@ module AvaliationHelper
     end
   end
 
+  def avaliation_data(avaliation)
+    @classroom = avaliation.classroom
+    @is_multi = @classroom.multi_grade?
+    @grades = grades_by_classroom
+    @input_value = if @classroom.multi_grade? && avaliation.grade_ids.empty?
+                     ''
+                   elsif avaliation.grade_ids.present?
+                     avaliation.grade_ids.join(',')
+                   else
+                     @grades.first[:id]
+                   end
+  end
+
+  def grades_by_classroom
+    if @classroom.multi_grade?
+      grades_to_select_2(ClassroomsGrade.includes(:grade)
+                                        .by_classroom_id(@classroom.id)
+                                        .by_score_type(ScoreTypes::NUMERIC)
+                                        .order_by_grade_description)
+    else
+      grades_to_select_2(@classroom.first_classroom_grade)
+    end
+  end
+
+  def grades_to_select_2(classroom_grades)
+    grades = []
+
+    if @classroom.multi_grade?
+      classroom_grades.each do |classroom_grade|
+        grades << build_grades(classroom_grade.grade)
+      end
+    else
+      grades << build_grades(classroom_grades.grade)
+    end
+
+    grades
+  end
+
+  def build_grades(grade)
+    { id: grade.id, name: grade.description, text: grade.description }
+  end
 end

--- a/app/helpers/daily_note_helper.rb
+++ b/app/helpers/daily_note_helper.rb
@@ -2,7 +2,7 @@ module DailyNoteHelper
   def do_undo_link(student, daily_note)
     exempted = student.exempted
     student_id = student.student_id
-    target = if exempted
+    target = if exempted && !student.in_active_search
                undo_exemption_daily_note_path(daily_note,
                                               avaliation_id: daily_note.avaliation_id,
                                               student_id: student_id)
@@ -13,10 +13,13 @@ module DailyNoteHelper
     classes = 'btn'
     classes << ' btn-default undo-exemption' if exempted
     classes << ' btn-primary do-exemption open-exemption-modal' unless exempted
+    classes << ' readonly' if student.in_active_search
     title = exempted ? 'Desfazer' : 'Dispensar'
+    data = exempted && !student.in_active_search ? { remote: true, method: 'post' } : { student_id: student_id }
+    styles = 'float: right;'
+    styles << ' pointer-events: none;' if student.in_active_search
 
-    data = exempted ? { remote: true, method: 'post' } : { student_id: student_id }
-
-    link_to('', target, class: classes, title: title, data: data, style: 'float: right;', id: "do_undo_exemption_#{student_id}")
+    link_to('', target, class: classes, title: title, data: data, style: styles,
+                        id: "do_undo_exemption_#{student_id}")
   end
 end

--- a/app/inputs/select2_grade_input.rb
+++ b/app/inputs/select2_grade_input.rb
@@ -4,8 +4,10 @@ class Select2GradeInput < Select2Input
     raise "User must be passed" unless options[:user].is_a? User
 
     if options[:user].current_classroom.present?
-      input_html_options[:readonly] = 'readonly'
-      input_html_options[:value] = options[:user].current_classroom.grade.id
+      classroom = options[:user].current_classroom
+
+      input_html_options[:readonly] = 'readonly' unless classroom.multi_grade?
+      input_html_options[:value] = classroom.grades.first.id unless classroom.multi_grade?
     end
 
     super(wrapper_options)
@@ -17,11 +19,11 @@ class Select2GradeInput < Select2Input
     grades = []
 
     if user.current_classroom.present?
-      grades = [ user.current_classroom.grade ]
+      grades = user.current_classroom.grades
     elsif user.current_teacher.present?
-      grades = user.current_teacher.classrooms.map(&:grade).uniq
+      grades = user.current_teacher.classrooms.map(&:grades).uniq
     elsif user.current_unity.present?
-      grades = user.current_unity.classrooms.with_grade.map(&:grade).uniq
+      grades = user.current_unity.classrooms.with_grade.map(&:grades).uniq
     end
 
     options[:elements] = grades

--- a/app/inputs/select2_grade_input.rb
+++ b/app/inputs/select2_grade_input.rb
@@ -19,11 +19,14 @@ class Select2GradeInput < Select2Input
     grades = []
 
     if user.current_classroom.present?
-      grades = user.current_classroom.grades
+      grades = Grade.joins(classrooms_grades: :classroom)
+                    .where(classrooms: { id: user.current_classroom })
     elsif user.current_teacher.present?
-      grades = user.current_teacher.classrooms.map(&:grades).uniq
+      grades = Grade.joins(classrooms_grades: :classroom)
+                    .where(classrooms: { id: user.current_teacher.classrooms })
     elsif user.current_unity.present?
-      grades = user.current_unity.classrooms.with_grade.map(&:grades).uniq
+      grades = Grade.joins(classrooms_grades: :classroom)
+                    .where(classrooms: { id: user.current_unity.classrooms })
     end
 
     options[:elements] = grades

--- a/app/models/active_search.rb
+++ b/app/models/active_search.rb
@@ -1,7 +1,11 @@
 class ActiveSearch < ActiveRecord::Base
+  include Discardable
+
   belongs_to :student_enrollment
 
   has_enumeration_for :status, with: ActiveSearchStatus, create_helpers: true
+
+  default_scope -> { kept }
 
   def in_active_search?(student_enrollment_id, date)
     student_active_search = ActiveSearch.where(student_enrollment_id: student_enrollment_id)

--- a/app/models/avaliation.rb
+++ b/app/models/avaliation.rb
@@ -41,6 +41,7 @@ class Avaliation < ActiveRecord::Base
   validates :test_setting_test, presence: true, if: :sum_calculation_type?
   validates :description,       presence: true, if: -> { !sum_calculation_type? || allow_break_up? }
   validates :weight,            presence: true, if: :should_validate_weight?
+  validates :grade_ids,         presence: true
 
   validate :uniqueness_of_avaliation
   validate :unique_test_setting_test_per_step,    if: -> { sum_calculation_type? && !allow_break_up? }

--- a/app/models/avaliation.rb
+++ b/app/models/avaliation.rb
@@ -17,6 +17,7 @@ class Avaliation < ActiveRecord::Base
   before_destroy :try_destroy, if: :valid_for_destruction?
 
   belongs_to :classroom
+  has_and_belongs_to_many :grades
   belongs_to :discipline
   belongs_to :school_calendar
   belongs_to :test_setting
@@ -47,11 +48,16 @@ class Avaliation < ActiveRecord::Base
   validate :classroom_score_type_must_be_numeric, if: :should_validate_classroom_score_type?
   validate :is_school_term_day?
   validate :weight_not_greater_than_test_setting_maximum_score, if: :arithmetic_and_sum_calculation_type?
+  validate :grades_belongs_to_test_setting
+  validate :discipline_in_grade?
 
   scope :teacher_avaliations, lambda { |teacher_id, classroom_id, discipline_id| joins(:teacher_discipline_classrooms).where(teacher_discipline_classrooms: { teacher_id: teacher_id, classroom_id: classroom_id, discipline_id: discipline_id}) }
   scope :by_teacher, lambda { |teacher_id| joins(:teacher_discipline_classrooms).where(teacher_discipline_classrooms: { teacher_id: teacher_id }).uniq }
   scope :by_unity_id, lambda { |unity_id| joins(:classroom).merge(Classroom.by_unity(unity_id))}
   scope :by_classroom_id, lambda { |classroom_id| where(classroom_id: classroom_id) }
+  scope :by_grade_id, lambda { |grade_id|
+    joins(:avaliations_grades).where(avaliations_grades: { grade_id: grade_id })
+  }
   scope :by_discipline_id, lambda { |discipline_id| where(discipline_id: discipline_id) }
   scope :exclude_discipline_ids, lambda { |discipline_ids| where.not(discipline_id: discipline_ids) }
   scope :by_test_date, lambda { |test_date| where(test_date: test_date.try(:to_date)) }
@@ -147,6 +153,12 @@ class Avaliation < ActiveRecord::Base
     allow_break_up? || arithmetic_and_sum_calculation_type?
   end
 
+  def classroom_description
+    return classroom if grades.count == 1
+
+    "#{classroom} - #{grades.pluck(:description).join(', ')}"
+  end
+
   private
 
   def steps_fetcher
@@ -179,11 +191,14 @@ class Avaliation < ActiveRecord::Base
   end
 
   def classroom_score_type_must_be_numeric
-    return if classroom.exam_rule.nil?
+    exam_rules = classroom.classrooms_grades.map(&:exam_rule)
+    return if exam_rules.blank?
+
     right_score_types = [ScoreTypes::NUMERIC, ScoreTypes::NUMERIC_AND_CONCEPT]
-    unless right_score_types.include? classroom.exam_rule.score_type
-      errors.add(:classroom, :classroom_score_type_must_be_numeric)
-    end
+
+    no_score_type_included = exam_rules.none? { |exam_rule| right_score_types.include?(exam_rule.score_type) }
+
+    errors.add(:classroom, :classroom_score_type_must_be_numeric) if no_score_type_included
   end
 
   def step
@@ -194,6 +209,7 @@ class Avaliation < ActiveRecord::Base
 
   def uniqueness_of_avaliation
     avaliations = Avaliation.by_classroom_id(classroom_id)
+                            .by_grade_id(grade_ids)
                             .by_discipline_id(discipline)
                             .by_test_date(test_date)
                             .by_classes(classes)
@@ -206,6 +222,7 @@ class Avaliation < ActiveRecord::Base
     return unless step
 
     avaliations = Avaliation.by_classroom_id(classroom_id)
+                            .by_grade_id(grade_ids)
                             .by_discipline_id(discipline)
                             .by_test_setting_test_id(test_setting_test_id)
                             .by_test_date_between(step.start_at, step.end_at)
@@ -218,6 +235,7 @@ class Avaliation < ActiveRecord::Base
     return unless step && weight
 
     avaliations = Avaliation.by_classroom_id(classroom_id)
+                            .by_grade_id(grade_ids)
                             .by_discipline_id(discipline)
                             .by_test_setting_test_id(test_setting_test_id)
                             .by_test_date_between(step.start_at, step.end_at)
@@ -255,5 +273,22 @@ class Avaliation < ActiveRecord::Base
     if weight > test_setting.maximum_score
       errors.add(:weight, :cant_be_greater_than, value: test_setting.maximum_score)
     end
+  end
+
+  def grades_belongs_to_test_setting
+    return unless test_setting.general_by_school?
+    return if (grade_ids - test_setting.grades).empty?
+
+    errors.add(:grades, :should_be_in_test_setting)
+  end
+
+  def discipline_in_grade?
+    return if SchoolCalendarDisciplineGrade.exists?(
+      school_calendar_id: school_calendar_id,
+      discipline_id: discipline_id,
+      grade_id: grade_ids
+    )
+
+    errors.add(:grades, :discipline_not_in_grades)
   end
 end

--- a/app/models/avaliation_exemption.rb
+++ b/app/models/avaliation_exemption.rb
@@ -42,8 +42,9 @@ class AvaliationExemption < ActiveRecord::Base
            :classroom, :discipline,
            to: :avaliation, prefix: false, allow_nil: true
   delegate :test_date, to: :avaliation, prefix: true, allow_nil: true
-  delegate :grade_id, :grade, to: :classroom, prefix: false, allow_nil: true
-  delegate :course_id, to: :grade, prefix: false, allow_nil: true
+  delegate :grades, :first_grade, :first_classroom_grade, to: :classroom, prefix: false, allow_nil: true
+  delegate :grade_id, to: :first_classroom_grade, prefix: false, allow_nil: true
+  delegate :course_id, to: :first_grade, prefix: false, allow_nil: true
 
   default_scope -> { kept }
 
@@ -60,7 +61,7 @@ class AvaliationExemption < ActiveRecord::Base
   end)
 
   scope :by_grade_description, lambda { |grade_description|
-    joins(avaliation: [classroom: :grade])
+    joins(avaliation: [{ classroom: { classrooms_grades: :grade } }])
     .where('unaccent(grades.description) ILIKE unaccent(?)', "%#{grade_description}%" )
   }
 

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -23,6 +23,7 @@ class Classroom < ActiveRecord::Base
   has_many :labels, through: :classroom_labels
   has_many :classrooms_grades, dependent: :destroy
   has_many :grades, through: :classrooms_grades
+  has_many :student_enrollment_classrooms, through: :classrooms_grades
 
   before_create :set_label_color
 

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -21,7 +21,7 @@ class Classroom < ActiveRecord::Base
   has_many :students, through: :student_enrollments
   has_many :classroom_labels, dependent: :destroy
   has_many :labels, through: :classroom_labels
-  has_many :classrooms_grades
+  has_many :classrooms_grades, dependent: :destroy
   has_many :grades, through: :classrooms_grades
 
   before_create :set_label_color

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -12,23 +12,23 @@ class Classroom < ActiveRecord::Base
   has_enumeration_for :period, with: Periods
 
   belongs_to :unity
-  belongs_to :exam_rule
-  belongs_to :grade
   has_many :teacher_discipline_classrooms, dependent: :destroy
   has_many :disciplines, through: :teacher_discipline_classrooms
   has_one :calendar, class_name: 'SchoolCalendarClassroom'
   has_many :users, foreign_key: :current_classroom_id, dependent: :nullify
-  has_many :student_enrollment_classrooms
-  has_many :student_enrollments, through: :student_enrollment_classrooms
   has_many :conceptual_exams, dependent: :restrict_with_error
   has_many :infrequency_trackings, dependent: :restrict_with_error
   has_many :students, through: :student_enrollments
+  has_many :classroom_labels, dependent: :destroy
+  has_many :labels, through: :classroom_labels
+  has_many :classrooms_grades
+  has_many :grades, through: :classrooms_grades
 
   before_create :set_label_color
 
   delegate :course_id, :course, to: :grade, prefix: false
 
-  validates :description, :api_code, :unity_code, :year, :grade, presence: true
+  validates :description, :api_code, :unity_code, :year, presence: true
   validates :api_code, uniqueness: true
 
   default_scope -> { kept }
@@ -40,9 +40,9 @@ class Classroom < ActiveRecord::Base
   }
 
   scope :by_unity, ->(unity) { where(unity: unity) }
-  scope :by_unity_and_grade, ->(unity_id, grade_id) { where(unity_id: unity_id, grade_id: grade_id).uniq }
+  scope :by_unity_and_grade, ->(unity_id, grade_id) { where(unity_id: unity_id).by_grade(grade_id).uniq }
   scope :different_than, ->(classroom_id) { where(arel_table[:id].not_eq(classroom_id)) }
-  scope :by_grade, ->(grade_id) { where(grade_id: grade_id) }
+  scope :by_grade, ->(grade_id) { joins(:classrooms_grades).merge(ClassroomsGrade.by_grade_id(grade_id)) }
   scope :by_year, ->(year) { where(year: year) }
   scope :by_period, ->(period) { where(period: period) }
 
@@ -52,7 +52,9 @@ class Classroom < ActiveRecord::Base
       .uniq
   }
 
-  scope :by_score_type, ->(score_type) { where('exam_rules.score_type' => score_type).includes(:exam_rule) }
+  scope :by_score_type, lambda { |score_type|
+    joins(:classrooms_grades).merge(ClassroomsGrade.by_score_type(score_type))
+  }
   scope :ordered, -> { order(arel_table[:description].asc) }
   scope :by_api_code, ->(api_code) { where(api_code: api_code) }
 
@@ -64,7 +66,7 @@ class Classroom < ActiveRecord::Base
 
   scope :by_api_code, ->(api_code) { where(api_code: api_code) }
   scope :by_id, ->(id) { where(id: id) }
-  scope :with_grade, -> { where.not(grade: nil) }
+  scope :with_grade, -> { joins(:classrooms_grades).where.not(classrooms_grades: { grade: nil }) }
 
   after_discard do
     teacher_discipline_classrooms.discard_all
@@ -83,9 +85,21 @@ class Classroom < ActiveRecord::Base
   end
 
   def has_differentiated_students?
-    student_enrollment_classrooms.joins(student_enrollment: :student )
-                                 .where(students: { uses_differentiated_exam_rule: true } )
-                                 .exists?
+    classrooms_grades.joins(student_enrollment_classrooms: [student_enrollment: :student])
+                     .where(students: { uses_differentiated_exam_rule: true })
+                     .exists?
+  end
+
+  def multi_grade?
+    grades.count > 1
+  end
+
+  def first_exam_rule
+    classrooms_grades.first.exam_rule
+  end
+
+  def courses
+    grades.map(&:course)
   end
 
   def number_of_classes

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -98,6 +98,10 @@ class Classroom < ActiveRecord::Base
     classrooms_grades.first.exam_rule
   end
 
+  def first_grade
+    classrooms_grades.first.grade
+  end
+
   def courses
     grades.map(&:course)
   end

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -70,10 +70,12 @@ class Classroom < ActiveRecord::Base
 
   after_discard do
     teacher_discipline_classrooms.discard_all
+    classrooms_grades.discard_all
   end
 
   after_undiscard do
     teacher_discipline_classrooms.undiscard_all
+    classrooms_grades.undiscard_all
   end
 
   def to_s

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -26,7 +26,7 @@ class Classroom < ActiveRecord::Base
 
   before_create :set_label_color
 
-  delegate :course_id, :course, to: :grade, prefix: false
+  delegate :course_id, :course, to: :first_grade, prefix: false
 
   validates :description, :api_code, :unity_code, :year, presence: true
   validates :api_code, uniqueness: true
@@ -100,6 +100,10 @@ class Classroom < ActiveRecord::Base
 
   def first_grade
     classrooms_grades.first.grade
+  end
+
+  def first_classroom_grade
+    classrooms_grades.first
   end
 
   def courses

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -9,6 +9,7 @@ class ClassroomsGrade < ActiveRecord::Base
 
   has_many :student_enrollment_classrooms
   has_many :student_enrollments, through: :student_enrollment_classrooms
+  has_one :lessons_board
 
   default_scope -> { kept }
 
@@ -26,9 +27,11 @@ class ClassroomsGrade < ActiveRecord::Base
 
   after_discard do
     student_enrollment_classrooms.discard_all
+    lessons_board.discard
   end
 
   after_undiscard do
     student_enrollment_classrooms.undiscard_all
+    lessons_board.undiscard
   end
 end

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -3,6 +3,8 @@ class ClassroomsGrade < ActiveRecord::Base
   belongs_to :grade
   belongs_to :exam_rule
 
+  delegate :year, to: :classroom
+
   has_many :student_enrollment_classrooms
   has_many :student_enrollments, through: :student_enrollment_classrooms
 

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -1,4 +1,6 @@
 class ClassroomsGrade < ActiveRecord::Base
+  include Discardable
+
   belongs_to :classroom
   belongs_to :grade
   belongs_to :exam_rule
@@ -7,6 +9,8 @@ class ClassroomsGrade < ActiveRecord::Base
 
   has_many :student_enrollment_classrooms
   has_many :student_enrollments, through: :student_enrollment_classrooms
+
+  default_scope -> { kept }
 
   scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
   scope :by_score_type, ->(score_type) { joins(:exam_rule).where(exam_rules: { score_type: score_type }) }

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -1,0 +1,19 @@
+class ClassroomsGrade < ActiveRecord::Base
+  belongs_to :classroom
+  belongs_to :grade
+  belongs_to :exam_rule
+
+  has_many :student_enrollment_classrooms
+  has_many :student_enrollments, through: :student_enrollment_classrooms
+
+  scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
+  scope :by_score_type, ->(score_type) { joins(:exam_rule).where(exam_rules: { score_type: score_type }) }
+  scope :by_grade_id, ->(grade_id) { where(grade_id: grade_id) }
+  scope :by_opinion_type, ->(opinion_type) { joins(:exam_rule).where(exam_rules: { opinion_type: opinion_type }) }
+  scope :by_exam_rule, ->(exam_rule_id) { joins(:exam_rule).where(exam_rules: { id: exam_rule_id }) }
+  scope :by_id, ->(id) { joins(:exam_rule).where(id: id) }
+  scope :by_year, ->(year) { joins(:classroom).where(classrooms: { year: year }) }
+  scope :by_student_id, lambda { |student_id|
+    joins(:student_enrollments).where(student_enrollments: { student_id: student_id })
+  }
+end

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -22,6 +22,7 @@ class ClassroomsGrade < ActiveRecord::Base
   scope :by_student_id, lambda { |student_id|
     joins(:student_enrollments).where(student_enrollments: { student_id: student_id })
   }
+  scope :order_by_grade_description, -> { joins(:grade).merge(Grade.ordered) }
 
   after_discard do
     student_enrollment_classrooms.discard_all

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -27,11 +27,11 @@ class ClassroomsGrade < ActiveRecord::Base
 
   after_discard do
     student_enrollment_classrooms.discard_all
-    lessons_board.discard
+    lessons_board&.discard
   end
 
   after_undiscard do
     student_enrollment_classrooms.undiscard_all
-    lessons_board.undiscard
+    lessons_board&.undiscard
   end
 end

--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -22,4 +22,12 @@ class ClassroomsGrade < ActiveRecord::Base
   scope :by_student_id, lambda { |student_id|
     joins(:student_enrollments).where(student_enrollments: { student_id: student_id })
   }
+
+  after_discard do
+    student_enrollment_classrooms.discard_all
+  end
+
+  after_undiscard do
+    student_enrollment_classrooms.undiscard_all
+  end
 end

--- a/app/models/conceptual_exam.rb
+++ b/app/models/conceptual_exam.rb
@@ -148,7 +148,12 @@ class ConceptualExam < ActiveRecord::Base
     return if student.blank? || classroom.blank?
 
     permited_score_types = [ScoreTypes::CONCEPT, ScoreTypes::NUMERIC_AND_CONCEPT]
-    exam_rule = classroom.exam_rule
+    classroom_grade = ClassroomsGrade.by_student_id(student.id).by_classroom_id(classroom.id)&.first
+
+    return if classroom_grade.blank?
+
+    exam_rule = classroom_grade&.exam_rule
+    exam_rule = (exam_rule.differentiated_exam_rule || exam_rule) if student.uses_differentiated_exam_rule
 
     if student.uses_differentiated_exam_rule
       exam_rule = exam_rule.differentiated_exam_rule || exam_rule

--- a/app/models/conceptual_exam_value.rb
+++ b/app/models/conceptual_exam_value.rb
@@ -56,8 +56,10 @@ class ConceptualExamValue < ActiveRecord::Base
           and(TeacherDisciplineClassroom.arel_table[:discipline_id].eq(arel_table[:discipline_id]))).join_sources,
       arel_table.join(Classroom.arel_table).
         on(Classroom.arel_table[:id].eq(ConceptualExam.arel_table[:classroom_id])).join_sources,
+      arel_table.join(ClassroomsGrade.arel_table).
+        on(ClassroomsGrade.arel_table[:classroom_id].eq(ConceptualExam.arel_table[:classroom_id])).join_sources,
       arel_table.join(ExamRule.arel_table).
-        on(ExamRule.arel_table[:id].eq(Classroom.arel_table[:exam_rule_id])).join_sources,
+        on(ExamRule.arel_table[:id].eq(ClassroomsGrade.arel_table[:exam_rule_id])).join_sources,
       arel_table.join(differentiated_exam_rule_students, Arel::Nodes::OuterJoin).
         on(differentiated_exam_rule_students[:id].eq(ConceptualExam.arel_table[:student_id]).
           and(differentiated_exam_rule_students[:uses_differentiated_exam_rule].eq(true))).join_sources,

--- a/app/models/concerns/stepable.rb
+++ b/app/models/concerns/stepable.rb
@@ -47,9 +47,18 @@ module Stepable
 
   def ensure_is_school_day
     return unless classroom.present? && recorded_at.present? && school_calendar.present?
-    return if school_calendar.school_day?(recorded_at, classroom.grade.id, classroom.id, nil)
 
-    errors.add(:recorded_at, :not_school_term_day)
+    school_day = true
+    grade_ids = classroom.grade_ids
+
+    loop do
+      grade_id = grade_ids&.shift
+      school_day = false unless school_calendar.school_day?(recorded_at, grade_id, classroom.id, nil)
+
+      break if grade_ids.blank? || !school_day
+    end
+
+    errors.add(:recorded_at, :not_school_term_day) unless school_day
   end
 
   def recorded_at_is_in_selected_step

--- a/app/models/content_record.rb
+++ b/app/models/content_record.rb
@@ -32,8 +32,7 @@ class ContentRecord < ActiveRecord::Base
   validates :teacher, presence: true
   validate :at_least_one_content
 
-  delegate :grade_id, to: :classroom
-  delegate :grade, :grade_id, to: :classroom
+  delegate :grades, :grade_ids, to: :classroom
 
   scope :by_unity_id, lambda { |unity_id| joins(:classroom).merge(Classroom.by_unity(unity_id)) }
   scope :by_teacher_id, lambda { |teacher_id| where(teacher_id: teacher_id) }

--- a/app/models/content_record.rb
+++ b/app/models/content_record.rb
@@ -32,7 +32,7 @@ class ContentRecord < ActiveRecord::Base
   validates :teacher, presence: true
   validate :at_least_one_content
 
-  delegate :grades, :grade_ids, to: :classroom
+  delegate :grades, :grade_ids, :first_grade, to: :classroom
 
   scope :by_unity_id, lambda { |unity_id| joins(:classroom).merge(Classroom.by_unity(unity_id)) }
   scope :by_teacher_id, lambda { |teacher_id| where(teacher_id: teacher_id) }

--- a/app/models/daily_note.rb
+++ b/app/models/daily_note.rb
@@ -65,7 +65,7 @@ class DailyNote < ActiveRecord::Base
     joins(:avaliation).merge(Avaliation.by_step_id(classroom, step_id))
   }
   scope :by_active_student_enrollment_classroom, lambda { |classroom_id|
-    joins(students: [student: :student_enrollments]).merge(
+    joins(students: [student: [student_enrollments: [:student_enrollment_classrooms]]]).merge(
       StudentEnrollment.by_classroom(classroom_id).active
     )
   }

--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -6,6 +6,8 @@ class Discipline < ActiveRecord::Base
   belongs_to :knowledge_area
   has_many :teacher_discipline_classrooms, dependent: :destroy
   has_and_belongs_to_many :absence_justifications
+  has_many :unity_discipline_grades
+  has_many :grades, through: :unity_discipline_grades
 
   validates :description, :api_code, :knowledge_area_id, presence: true
   validates :api_code, uniqueness: true
@@ -17,9 +19,10 @@ class Discipline < ActiveRecord::Base
   # teacher_discipline_classrooms. Using scopes like by_teacher_id or
   # by_classroom for example.
   scope :by_score_type, lambda { |score_type, student_id = nil|
-    scoped = joins(teacher_discipline_classrooms: { classroom: :exam_rule })
+    scoped = joins(teacher_discipline_classrooms: [classroom: [classrooms_grades: :exam_rule]])
+
     if student_id && Student.find(student_id).try(:uses_differentiated_exam_rule)
-      exam_rules = ExamRule.arel_table.alias('exam_rules_classrooms')
+      exam_rules = ExamRule.arel_table.alias('exam_rules_classrooms_grades')
 
       differentiated_exam_rules = ExamRule.arel_table.alias('differentiated_exam_rules')
         scoped.joins(
@@ -106,17 +109,9 @@ class Discipline < ActiveRecord::Base
       .uniq
   end
 
-  def self.by_grade(grade)
-    joins(:teacher_discipline_classrooms).joins(
-        arel_table.join(Classroom.arel_table)
-          .on(
-            Classroom.arel_table[:id]
-              .eq(TeacherDisciplineClassroom.arel_table[:classroom_id])
-          )
-          .join_sources
-      )
-      .where(classrooms: { grade_id: grade })
-      .uniq
+  def self.by_grade(grade_id)
+    joins(teacher_discipline_classrooms: [classroom: :classrooms_grades])
+      .where(classrooms_grades: { grade_id: grade_id }).uniq
   end
 
   def self.by_classroom(classroom)

--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -1,6 +1,10 @@
 class Discipline < ActiveRecord::Base
   acts_as_copy_target
 
+  LABEL_COLORS = YAML.safe_load(
+    File.open(Rails.root.join('config', 'label_colors.yml'))
+  ).with_indifferent_access[:label_colors].freeze
+
   audited
 
   belongs_to :knowledge_area
@@ -8,6 +12,8 @@ class Discipline < ActiveRecord::Base
   has_and_belongs_to_many :absence_justifications
   has_many :unity_discipline_grades
   has_many :grades, through: :unity_discipline_grades
+
+  before_create :set_label_color
 
   validates :description, :api_code, :knowledge_area_id, presence: true
   validates :api_code, uniqueness: true
@@ -119,5 +125,11 @@ class Discipline < ActiveRecord::Base
         teacher_discipline_classrooms: { classroom_id: classroom }
       )
       .uniq
+  end
+
+  private
+
+  def set_label_color
+    self.label_color = LABEL_COLORS.sample
   end
 end

--- a/app/models/discipline_content_record.rb
+++ b/app/models/discipline_content_record.rb
@@ -87,9 +87,11 @@ class DisciplineContentRecord < ActiveRecord::Base
                   content_record.school_calendar.present? &&
                   record_date.present?
 
-    unless content_record.school_calendar.school_day?(record_date, grades, classroom, discipline)
-      errors.add(:base, "")
-      content_record.errors.add(:record_date, :not_school_calendar_day)
+    grades.each do |grade|
+      unless content_record.school_calendar.school_day?(record_date, grade, classroom, discipline)
+        errors.add(:base, "")
+        content_record.errors.add(:record_date, :not_school_calendar_day)
+      end
     end
   end
 end

--- a/app/models/discipline_content_record.rb
+++ b/app/models/discipline_content_record.rb
@@ -48,7 +48,7 @@ class DisciplineContentRecord < ActiveRecord::Base
   validate :ensure_is_school_day
 
   delegate :contents, :record_date, :classroom, to: :content_record
-  delegate :grade, to: :classroom
+  delegate :grades, to: :classroom
 
   private
 
@@ -87,7 +87,7 @@ class DisciplineContentRecord < ActiveRecord::Base
                   content_record.school_calendar.present? &&
                   record_date.present?
 
-    unless content_record.school_calendar.school_day?(record_date, grade, classroom, discipline)
+    unless content_record.school_calendar.school_day?(record_date, grades, classroom, discipline)
       errors.add(:base, "")
       content_record.errors.add(:record_date, :not_school_calendar_day)
     end

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -8,6 +8,7 @@ class Entity < ActiveRecord::Base
 
   scope :active, -> { where(disabled: false) }
   scope :to_sync, -> { active.where(disabled_sync: false) }
+  scope :enable_to_sync, -> { active.to_sync }
 
   def self.current_domain
     raise Exception.new("Entity not found") if self.current.blank?

--- a/app/models/final_recovery_diary_record.rb
+++ b/app/models/final_recovery_diary_record.rb
@@ -81,10 +81,10 @@ class FinalRecoveryDiaryRecord < ActiveRecord::Base
 
   def uniqueness_of_recorded_at
     return unless recovery_diary_record
+
     relation = RecoveryDiaryRecord.find_by(unity_id: recovery_diary_record.unity_id, classroom_id: recovery_diary_record.classroom_id, discipline_id: recovery_diary_record.discipline_id)
-    if relation
-      recovery_diary_record.errors.add(:recorded_at, :uniqueness)
-    end
+
+    recovery_diary_record.errors.add(:recorded_at, :uniqueness_of_recorded_at) if relation
   end
 
   def valid_for_destruction?

--- a/app/models/grade.rb
+++ b/app/models/grade.rb
@@ -6,7 +6,10 @@ class Grade < ActiveRecord::Base
   audited
 
   belongs_to :course
-  has_many :classrooms
+  has_many :classrooms_grades
+  has_many :classrooms, through: :classrooms_grades
+  has_many :unity_discipline_grades
+  has_many :disciplines, through: :unity_discipline_grades
   has_many :mvw_infrequency_tracking_classrooms
 
   has_and_belongs_to_many :custom_rounding_tables

--- a/app/models/infrequency_tracking.rb
+++ b/app/models/infrequency_tracking.rb
@@ -14,7 +14,7 @@ class InfrequencyTracking < ActiveRecord::Base
   scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
   scope :by_student_id, ->(student_id) { where(student_id: student_id) }
   scope :by_unity_id, ->(unity_id) { joins(:classroom).where(classrooms: { unity_id: unity_id }) }
-  scope :by_grade_id, ->(grade_id) { joins(:classroom).where(classrooms: { grade_id: grade_id }) }
+  scope :by_grade_id, ->(grade_id) { joins(:classroom).merge(Classroom.by_grade(grade_id)) }
   scope :by_notification_date, ->(notification_date) { where(notification_date: notification_date.to_date) }
   scope :by_notification_type, ->(notification_type) { where(notification_type: notification_type) }
   scope :ordered, -> { order(notification_date: :desc) }

--- a/app/models/knowledge_area_content_record.rb
+++ b/app/models/knowledge_area_content_record.rb
@@ -43,7 +43,7 @@ class KnowledgeAreaContentRecord < ActiveRecord::Base
   validate :ensure_is_school_day
 
   delegate :contents, :classroom, :record_date, to: :content_record
-  delegate :grade, to: :classroom
+  delegate :grades, to: :classroom
 
   def knowledge_area_ids
     knowledge_areas.collect(&:id).join(',')

--- a/app/models/knowledge_area_content_record.rb
+++ b/app/models/knowledge_area_content_record.rb
@@ -86,7 +86,7 @@ class KnowledgeAreaContentRecord < ActiveRecord::Base
                   content_record.school_calendar.present? &&
                   record_date.present?
 
-    unless content_record.school_calendar.school_day?(record_date, grade, classroom)
+    unless content_record.school_calendar.school_day?(record_date, grades.first, classroom)
       errors.add(:base, "")
       content_record.errors.add(:record_date, :not_school_calendar_day)
     end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,14 @@
+class Label < ActiveRecord::Base
+  COLORS = %w(#9121AD #AD2121 #AD6421 #C9AC13 #21AD27 #21A5AD #212FAD #BC62D2 #D26262 #C88F5A #D8BC59 #5AB8CD
+              #5AB8CD #6274D2 #7A7A7A)
+
+  belongs_to :labelable, polymorphic: true
+
+  before_create :set_color
+
+  private
+
+  def set_color
+    self.color = COLORS.sample
+  end
+end

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -40,7 +40,7 @@ class LessonPlan < ActiveRecord::Base
   validate :at_least_one_assigned_content
 
   delegate :unity, :unity_id, to: :classroom
-  delegate :grades, :grade_ids, to: :classroom
+  delegate :grades, :grade_ids, :first_grade, to: :classroom
 
   scope :by_unity_id, lambda { |unity_id| joins(:classroom).merge(Classroom.by_unity(unity_id)) }
   scope :by_teacher_id, lambda { |teacher_id| where(teacher_id: teacher_id) }

--- a/app/models/lesson_plan.rb
+++ b/app/models/lesson_plan.rb
@@ -40,7 +40,7 @@ class LessonPlan < ActiveRecord::Base
   validate :at_least_one_assigned_content
 
   delegate :unity, :unity_id, to: :classroom
-  delegate :grade, :grade_id, to: :classroom
+  delegate :grades, :grade_ids, to: :classroom
 
   scope :by_unity_id, lambda { |unity_id| joins(:classroom).merge(Classroom.by_unity(unity_id)) }
   scope :by_teacher_id, lambda { |teacher_id| where(teacher_id: teacher_id) }

--- a/app/models/lessons_board.rb
+++ b/app/models/lessons_board.rb
@@ -9,7 +9,7 @@ class LessonsBoard < ActiveRecord::Base
   validates :classrooms_grade_id, presence: true, uniqueness: { scope: :period }
 
   belongs_to :classrooms_grade
-  has_many :lessons_board_lessons, dependent: :destroy
+  has_many :lessons_board_lessons
 
   attr_accessor :unity, :grade, :lessons_number, :classroom_id
 
@@ -29,4 +29,12 @@ class LessonsBoard < ActiveRecord::Base
   scope :by_discipline, ->(discipline_id) { joins(lessons_board_lessons: [lessons_board_lesson_weekdays: [:teacher_discipline_classroom]])
                                             .where(teacher_discipline_classrooms:  { discipline_id: discipline_id }) }
   scope :ordered, -> { order(created_at: :desc) }
+
+  after_discard do
+    lessons_board_lessons.discard_all
+  end
+
+  after_undiscard do
+    lessons_board_lessons.undiscard_all
+  end
 end

--- a/app/models/lessons_board.rb
+++ b/app/models/lessons_board.rb
@@ -1,31 +1,32 @@
 class LessonsBoard < ActiveRecord::Base
+  include Audit
   include Discardable
   include Filterable
 
   audited
 
   validates :period, presence: true
-  validates :classroom_id, presence: true, uniqueness: { scope: :period }
+  validates :classrooms_grade_id, presence: true, uniqueness: { scope: :period }
 
-
-  belongs_to :classroom
+  belongs_to :classrooms_grade
   has_many :lessons_board_lessons, dependent: :destroy
 
-  attr_accessor :unity, :grade, :lessons_number
+  attr_accessor :unity, :grade, :lessons_number, :classroom_id
 
   accepts_nested_attributes_for :lessons_board_lessons, allow_destroy: true
 
+  delegate :classroom, to: :classrooms_grade
 
   default_scope -> { kept }
 
-  scope :by_year, ->(year) { joins(:classroom).where(classrooms: { year: year }) }
-  scope :by_unity, ->(unity) { joins(:classroom).where(classrooms: { unity_id: unity }) }
-  scope :by_grade, ->(grade) { joins(:classroom).where(classrooms: { grade_id: grade }) }
-  scope :by_classroom, ->(classroom) { where(classroom_id: classroom) }
+  scope :by_year, ->(year) { joins(classrooms_grade: :classroom).where(classrooms: { year: year }) }
+  scope :by_unity, ->(unity) { joins(classrooms_grade: :classroom).where(classrooms: { unity_id: unity }) }
+  scope :by_grade, ->(grade) { joins(classrooms_grade: :classroom).merge(ClassroomsGrade.by_grade_id(grade)) }
+  scope :by_classroom, ->(classroom) { joins(:classrooms_grade).where(classrooms_grades: { classroom_id: classroom }) }
+  scope :by_period, ->(period) { where(lessons_boards: { period: period }) }
   scope :by_teacher, ->(teacher_id) { joins(lessons_board_lessons: [lessons_board_lesson_weekdays: [:teacher_discipline_classroom]])
                                       .where(teacher_discipline_classrooms:  { teacher_id: teacher_id }) }
   scope :by_discipline, ->(discipline_id) { joins(lessons_board_lessons: [lessons_board_lesson_weekdays: [:teacher_discipline_classroom]])
                                             .where(teacher_discipline_classrooms:  { discipline_id: discipline_id }) }
   scope :ordered, -> { order(created_at: :desc) }
-
 end

--- a/app/models/lessons_board.rb
+++ b/app/models/lessons_board.rb
@@ -15,7 +15,7 @@ class LessonsBoard < ActiveRecord::Base
 
   accepts_nested_attributes_for :lessons_board_lessons, allow_destroy: true
 
-  delegate :classroom, to: :classrooms_grade
+  delegate :classroom, :classroom_id, to: :classrooms_grade
 
   default_scope -> { kept }
 

--- a/app/models/lessons_board_lesson.rb
+++ b/app/models/lessons_board_lesson.rb
@@ -4,9 +4,17 @@ class LessonsBoardLesson < ActiveRecord::Base
   audited
 
   belongs_to :lessons_board
-  has_many :lessons_board_lesson_weekdays, dependent: :destroy
+  has_many :lessons_board_lesson_weekdays
 
   accepts_nested_attributes_for :lessons_board_lesson_weekdays, allow_destroy: true
 
   default_scope -> { kept }
+
+  after_discard do
+    lessons_board_lesson_weekdays.discard_all
+  end
+
+  after_undiscard do
+    lessons_board_lesson_weekdays.undiscard_all
+  end
 end

--- a/app/models/recovery_diary_record.rb
+++ b/app/models/recovery_diary_record.rb
@@ -12,7 +12,7 @@ class RecoveryDiaryRecord < ActiveRecord::Base
   has_associated_audits
 
   belongs_to :unity
-  belongs_to :classroom, -> { includes(:exam_rule) }
+  belongs_to :classroom, -> { includes(:classrooms_grades) }
   belongs_to :discipline
 
   has_many :students, -> { includes(:student).ordered },

--- a/app/models/recovery_diary_record_student.rb
+++ b/app/models/recovery_diary_record_student.rb
@@ -43,11 +43,12 @@ class RecoveryDiaryRecordStudent < ActiveRecord::Base
   private
 
   def maximum_score_for_school_term_recovery
-    if recovery_diary_record.classroom.exam_rule.recovery_type == RecoveryTypes::SPECIFIC
-      recovery_exam_rule = recovery_diary_record.classroom
-        .exam_rule
-        .recovery_exam_rules
-        .find do |recovery_exam_rule|
+    if recovery_diary_record.classroom.first_exam_rule.recovery_type == RecoveryTypes::SPECIFIC
+      recovery_exam_rule = recovery_diary_record
+                           .classroom
+                           .first_exam_rule
+                           .recovery_exam_rules
+                           .find do |recovery_exam_rule|
           recovery_exam_rule.steps.last.eql?(
             recovery_diary_record.school_term_recovery_diary_record
               .step
@@ -65,7 +66,7 @@ class RecoveryDiaryRecordStudent < ActiveRecord::Base
   end
 
   def maximum_score_for_final_recovery
-    recovery_diary_record.classroom.exam_rule.final_recovery_maximum_score
+    recovery_diary_record.classroom.first_exam_rule.final_recovery_maximum_score
   end
 
   def maximum_score_for_avaliation_recovery

--- a/app/models/school_calendar_classroom.rb
+++ b/app/models/school_calendar_classroom.rb
@@ -16,7 +16,7 @@ class SchoolCalendarClassroom < ActiveRecord::Base
   scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
   scope :by_school_calendar_id, ->(school_calendar_id) { where(school_calendar_id: school_calendar_id) }
   scope :ordered_by_grade, lambda {
-    joins(:classroom).joins('inner join grades on (classrooms.grade_id = grades.id)').order('grades.course_id')
+    joins(classroom: [classrooms_grades: :grade]).order('grades.course_id')
   }
   scope :ordered_by_description, -> { joins(:classroom).order('classrooms.description') }
 

--- a/app/models/school_calendar_classroom_step.rb
+++ b/app/models/school_calendar_classroom_step.rb
@@ -46,11 +46,11 @@ class SchoolCalendarClassroomStep < ActiveRecord::Base
 
     return false unless step_from_date.eql?(self)
 
-    school_calendar.school_day?(date, classroom.grade, classroom)
+    school_calendar.school_day?(date, classroom.grade_ids, classroom)
   end
 
   def first_school_calendar_date
-    school_calendar.school_day_checker(start_at, classroom.grade_id, classroom_id).next_school_day
+    school_calendar.school_day_checker(start_at, classroom.grade_ids, classroom_id).next_school_day
   end
 
   def school_calendar

--- a/app/models/school_calendar_discipline_grade.rb
+++ b/app/models/school_calendar_discipline_grade.rb
@@ -1,0 +1,5 @@
+class SchoolCalendarDisciplineGrade < ActiveRecord::Base
+  belongs_to :school_calendar
+  belongs_to :discipline
+  belongs_to :grade
+end

--- a/app/models/school_calendar_event.rb
+++ b/app/models/school_calendar_event.rb
@@ -110,8 +110,8 @@ class SchoolCalendarEvent < ActiveRecord::Base
 
   def self.all_events_for_classroom(classroom)
     where('? = ANY (periods) OR classroom_id = ?', classroom.period, classroom.id).
-    where('grade_id IS NULL OR grade_id = ?', classroom.grade.id).
-    where('course_id IS NULL OR course_id = ?', classroom.grade.course_id)
+    where('grade_id IS NULL OR grade_id IN (?)', classroom.grade_ids).
+    where('course_id IS NULL OR course_id IN (?)', classroom.courses.map(&:id))
     where(' "school_calendar_events"."id" in (
             SELECT id
             FROM school_calendar_events sce
@@ -119,10 +119,10 @@ class SchoolCalendarEvent < ActiveRecord::Base
             AND sce.end_date <= "school_calendar_events"."end_date"
             AND sce.school_calendar_id = "school_calendar_events"."school_calendar_id"
             AND ((? = ANY (periods) AND classroom_id IS NULL) OR classroom_id = ?)
-            AND (grade_id IS NULL OR grade_id = ?)
-            AND (course_id iS NULL or course_id = ?)
+            AND (grade_id IS NULL OR grade_id IN (?))
+            AND (course_id iS NULL or course_id IN (?))
             ORDER BY COALESCE(classroom_id, 0) DESC, COALESCE(grade_id,0) DESC
-            )', classroom.period, classroom.id, classroom.grade.id, classroom.grade.course_id)
+            )', classroom.period, classroom.id, classroom.grade_ids, classroom.courses.map(&:id))
   end
 
   def should_validate_grade?

--- a/app/models/school_calendar_event.rb
+++ b/app/models/school_calendar_event.rb
@@ -33,6 +33,7 @@ class SchoolCalendarEvent < ActiveRecord::Base
   validate :uniqueness_of_start_at_in_course
   validate :uniqueness_of_end_at_in_course
   validate :uniqueness_of_start_at_and_end_at
+  validate :start_at_and_end_at_in_step
 
   scope :ordered, -> { order(arel_table[:start_date]) }
   scope :school_event, -> { where(event_type: [EventTypes::EXTRA_SCHOOL, EventTypes::EXTRA_SCHOOL_WITHOUT_FREQUENCY]) }
@@ -220,6 +221,25 @@ class SchoolCalendarEvent < ActiveRecord::Base
       errors.add(:start_date, 'deve ser menor que a data final')
       errors.add(:end_date, 'deve ser maior ou igual a data inicial')
     end
+  end
+
+  def start_at_and_end_at_in_step
+    return if school_calendar.nil?
+
+    start_date_in_any_step = false
+    end_date_in_any_step = false
+
+    school_calendar.steps.each do |step|
+        start_date_in_step = start_date.between?(step.start_at, step.end_at)
+        end_date_in_step = end_date.between?(step.start_at, step.end_at)
+        start_date_in_any_step = true if start_date_in_step
+        end_date_in_any_step = true if end_date_in_step
+
+        break if start_date_in_step && end_date_in_step
+    end
+
+    errors.add(:start_date, I18n.t('errors.messages.is_not_between_steps')) unless start_date_in_any_step
+    errors.add(:end_date, I18n.t('errors.messages.is_not_between_steps')) unless end_date_in_any_step
   end
 
   def uniqueness_of_start_at_and_end_at

--- a/app/models/school_term_recovery_diary_record.rb
+++ b/app/models/school_term_recovery_diary_record.rb
@@ -88,8 +88,7 @@ class SchoolTermRecoveryDiaryRecord < ActiveRecord::Base
 
   def recovery_type_must_allow_recovery_for_classroom
     return if recovery_diary_record.blank? || classroom.blank?
-
-    if classroom.exam_rule.recovery_type == RecoveryTypes::DONT_USE
+    if classroom.first_exam_rule.recovery_type == RecoveryTypes::DONT_USE
       errors.add(:recovery_diary_record, :recovery_type_must_allow_recovery_for_classroom)
       recovery_diary_record.errors.add(:classroom, :recovery_type_must_allow_recovery_for_classroom)
     end
@@ -97,9 +96,9 @@ class SchoolTermRecoveryDiaryRecord < ActiveRecord::Base
 
   def recovery_type_must_allow_recovery_for_step
     return if recovery_diary_record.blank? || classroom.blank? || step.blank?
-    return if classroom.exam_rule.recovery_type != RecoveryTypes::SPECIFIC
+    return if classroom.first_exam_rule.recovery_type != RecoveryTypes::SPECIFIC
 
-    if classroom.exam_rule.recovery_exam_rules.none? { |r| r.steps.include?(step.to_number) }
+    if classroom.first_exam_rule.recovery_exam_rules.none? { |r| r.steps.include?(step.to_number) }
       errors.add(:step_id, :recovery_type_must_allow_recovery_for_step)
     end
   end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -44,15 +44,6 @@ class Student < ActiveRecord::Base
       "ts_rank_cd(students.name_tokens, plainto_tsquery('portuguese', '#{name}')) desc"
     )
   }
-  scope :order_by_sequence, lambda { |classroom_id, start_date, end_date|
-    joins(:student_enrollments)
-      .merge(
-        StudentEnrollment.by_classroom(classroom_id)
-                         .by_date_range(start_date, end_date)
-                         .active
-                         .ordered
-      )
-  }
 
   def self.search(value)
     relation = all

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -85,11 +85,11 @@ class Student < ActiveRecord::Base
   end
 
   def classrooms
-    Classroom.joins(:student_enrollment_classrooms).merge(StudentEnrollmentClassroom.by_student(self.id)).uniq
+    Classroom.joins(classrooms_grades: :student_enrollment_classrooms).merge(StudentEnrollmentClassroom.by_student(self.id)).uniq
   end
 
   def current_classrooms
-    Classroom.joins(:student_enrollment_classrooms).merge(
+    Classroom.joins(classrooms_grades: :student_enrollment_classrooms).merge(
       StudentEnrollmentClassroom.by_student(id)
                                 .by_date(Date.current)
     ).uniq

--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -101,25 +101,29 @@ class StudentEnrollment < ActiveRecord::Base
   def self.by_opinion_type_query(opinion_type, classroom_id)
     return where(nil) unless opinion_type.present? && classroom_id.present?
 
-    classrooms_grades = ClassroomsGrade.by_classroom_id(classroom_id).by_opinion_type(opinion_type)
-    exam_rules = classrooms_grades.map(&:exam_rule)
+    classrooms_grades = ClassroomsGrade.by_classroom_id(classroom_id)
+                                       .includes(student_enrollment_classrooms: [student_enrollment: :student])
+                                       .includes(exam_rule: :differentiated_exam_rule)
+    students_by_opinion_type = []
 
-    return where(nil) if exam_rules.blank?
+    classrooms_grades.each do |classroom_grade|
+      exam_rule = classroom_grade.exam_rule.opinion_type.eql?(opinion_type)
+      differentiated_exam_rule = classroom_grade.exam_rule&.differentiated_exam_rule&.opinion_type.eql?(opinion_type)
 
-    differentiated_exam_rules = exam_rules.map(&:differentiated_exam_rule).compact.presence || exam_rules
+      classroom_grade.student_enrollment_classrooms.each do |student_enrollment_classroom|
+        differentiated = student_enrollment_classroom.student_enrollment
+                                                     .student
+                                                     .uses_differentiated_exam_rule
+        if differentiated && differentiated_exam_rule
+          students_by_opinion_type << student_enrollment_classroom.id
+        elsif exam_rule && !differentiated
+          students_by_opinion_type << student_enrollment_classroom.id
+        end
+      end
+    end
 
-    exam_rule_included = exam_rules.any? { |exam_rule| exam_rule.opinion_type == opinion_type }
-    differentiated_exam_rule_included = differentiated_exam_rules.any? { |differentiated_exam_rule|
-      differentiated_exam_rule.opinion_type == opinion_type
-    }
-
-    scoped = joins(:student_enrollment_classrooms)
-             .where(student_enrollment_classrooms: { classrooms_grade_id: classrooms_grades.pluck(:id) })
-
-    return scoped.where(nil) if exam_rule_included && differentiated_exam_rule_included
-    return none unless exam_rule_included || differentiated_exam_rule_included
-
-    scoped.joins(:student).where(students: { uses_differentiated_exam_rule: differentiated_exam_rule_included })
+    joins(:student_enrollment_classrooms)
+      .where(student_enrollment_classrooms: { id: students_by_opinion_type })
   end
 
   def self.exclude_exempted_disciplines(discipline_id, step_number)

--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -108,7 +108,8 @@ class StudentEnrollment < ActiveRecord::Base
 
     classrooms_grades.each do |classroom_grade|
       exam_rule = classroom_grade.exam_rule.opinion_type.eql?(opinion_type)
-      differentiated_exam_rule = classroom_grade.exam_rule&.differentiated_exam_rule&.opinion_type.eql?(opinion_type)
+      differentiated_exam_rule = classroom_grade.exam_rule&.differentiated_exam_rule&.opinion_type.eql?(opinion_type) ||
+                                   exam_rule
 
       classroom_grade.student_enrollment_classrooms.each do |student_enrollment_classroom|
         differentiated = student_enrollment_classroom.student_enrollment

--- a/app/models/student_enrollment.rb
+++ b/app/models/student_enrollment.rb
@@ -18,6 +18,9 @@ class StudentEnrollment < ActiveRecord::Base
   default_scope -> { kept }
 
   scope :by_classroom, lambda { |classroom_id| joins(:student_enrollment_classrooms).merge(StudentEnrollmentClassroom.by_classroom(classroom_id)) }
+  scope :by_grade, lambda { |grade_id|
+    joins(:student_enrollment_classrooms).merge(StudentEnrollmentClassroom.by_grade(grade_id))
+  }
   scope :by_discipline, lambda {|discipline_id| by_discipline_query(discipline_id)}
   scope :by_score_type, lambda {|score_type, classroom_id| by_score_type_query(score_type, classroom_id)}
   scope :by_opinion_type, lambda {|opinion_type, classroom_id| by_opinion_type_query(opinion_type, classroom_id)}
@@ -47,7 +50,7 @@ class StudentEnrollment < ActiveRecord::Base
   end
 
   def self.with_recovery_note_in_step_query(step, discipline_id)
-    joins(:student_enrollment_classrooms).where('
+    joins(student_enrollment_classrooms: :classrooms_grade).where('
       ( EXISTS(
         SELECT 1
         FROM recovery_diary_records
@@ -55,7 +58,7 @@ class StudentEnrollment < ActiveRecord::Base
         ON recovery_diary_records.id = school_term_recovery_diary_records.recovery_diary_record_id
         JOIN recovery_diary_record_students
         ON recovery_diary_record_students.recovery_diary_record_id = recovery_diary_records.id
-        WHERE recovery_diary_records.classroom_id = student_enrollment_classrooms.classroom_id
+        WHERE recovery_diary_records.classroom_id = classrooms_grades.classroom_id
         AND recovery_diary_records.discipline_id = ?
         AND recovery_diary_records.recorded_at BETWEEN ? AND ?
         AND recovery_diary_record_students.student_id = student_enrollments.student_id
@@ -66,39 +69,57 @@ class StudentEnrollment < ActiveRecord::Base
 
   def self.by_score_type_query(score_type, classroom_id)
     return where(nil) if score_type == StudentEnrollmentScoreTypeFilters::BOTH
-    classroom = Classroom.find(classroom_id)
-    exam_rule = classroom.exam_rule
 
-    return where(nil) if exam_rule.blank?
+    score_type = case score_type
+                 when StudentEnrollmentScoreTypeFilters::CONCEPT then ScoreTypes::CONCEPT
+                 else ScoreTypes::NUMERIC
+                 end
 
-    differentiated_exam_rule = exam_rule.differentiated_exam_rule || exam_rule
+    classrooms_grades = ClassroomsGrade.by_classroom_id(classroom_id).by_score_type(score_type)
+    exam_rules = classrooms_grades.map(&:exam_rule)
 
-    allowed_score_types = [ScoreTypes::NUMERIC_AND_CONCEPT]
-    allowed_score_types << (score_type == StudentEnrollmentScoreTypeFilters::CONCEPT ? ScoreTypes::CONCEPT : ScoreTypes::NUMERIC)
+    return where(nil) if exam_rules.blank?
 
-    exam_rule_included = allowed_score_types.include?(exam_rule.score_type)
-    differentiated_exam_rule_included = allowed_score_types.include?(differentiated_exam_rule.score_type)
+    differentiated_exam_rules = exam_rules.map(&:differentiated_exam_rule).compact.presence || exam_rules
 
-    return where(nil) if exam_rule_included && differentiated_exam_rule_included
+    allowed_score_types = [ScoreTypes::NUMERIC_AND_CONCEPT, score_type]
+
+    exam_rule_included = exam_rules.any? { |exam_rule| allowed_score_types.include?(exam_rule.score_type) }
+    differentiated_exam_rule_included = differentiated_exam_rules.any? { |differentiated_exam_rule|
+      allowed_score_types.include?(differentiated_exam_rule.score_type)
+    }
+
+    scoped = joins(:student_enrollment_classrooms)
+             .where(student_enrollment_classrooms: { classrooms_grade_id: classrooms_grades.pluck(:id) })
+
+    return scoped.where(nil) if exam_rule_included && differentiated_exam_rule_included
     return none unless exam_rule_included || differentiated_exam_rule_included
-    return joins(:student).where(students: {uses_differentiated_exam_rule: differentiated_exam_rule_included})
+
+    scoped.joins(:student).where(students: { uses_differentiated_exam_rule: differentiated_exam_rule_included })
   end
 
   def self.by_opinion_type_query(opinion_type, classroom_id)
     return where(nil) unless opinion_type.present? && classroom_id.present?
-    classroom = Classroom.find(classroom_id)
-    exam_rule = classroom.exam_rule
 
-    return where(nil) if exam_rule.blank?
+    classrooms_grades = ClassroomsGrade.by_classroom_id(classroom_id).by_opinion_type(opinion_type)
+    exam_rules = classrooms_grades.map(&:exam_rule)
 
-    differentiated_exam_rule = exam_rule.differentiated_exam_rule || exam_rule
+    return where(nil) if exam_rules.blank?
 
-    exam_rule_included = exam_rule.opinion_type == opinion_type
-    differentiated_exam_rule_included = differentiated_exam_rule.opinion_type == opinion_type
+    differentiated_exam_rules = exam_rules.map(&:differentiated_exam_rule).compact.presence || exam_rules
 
-    return where(nil) if exam_rule_included && differentiated_exam_rule_included
+    exam_rule_included = exam_rules.any? { |exam_rule| exam_rule.opinion_type == opinion_type }
+    differentiated_exam_rule_included = differentiated_exam_rules.any? { |differentiated_exam_rule|
+      differentiated_exam_rule.opinion_type == opinion_type
+    }
+
+    scoped = joins(:student_enrollment_classrooms)
+             .where(student_enrollment_classrooms: { classrooms_grade_id: classrooms_grades.pluck(:id) })
+
+    return scoped.where(nil) if exam_rule_included && differentiated_exam_rule_included
     return none unless exam_rule_included || differentiated_exam_rule_included
-    return joins(:student).where(students: {uses_differentiated_exam_rule: differentiated_exam_rule_included})
+
+    scoped.joins(:student).where(students: { uses_differentiated_exam_rule: differentiated_exam_rule_included })
   end
 
   def self.exclude_exempted_disciplines(discipline_id, step_number)

--- a/app/models/unique_daily_frequency_student.rb
+++ b/app/models/unique_daily_frequency_student.rb
@@ -9,7 +9,7 @@ class UniqueDailyFrequencyStudent < ActiveRecord::Base
   scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
   scope :by_student_id, ->(student_id) { where(student_id: student_id) }
   scope :by_unity_id, ->(unity_id) { joins(:classroom).where(classrooms: { unity_id: unity_id }) }
-  scope :by_grade_id, ->(grade_id) { joins(:classroom).where(classrooms: { grade_id: grade_id }) }
+  scope :by_grade_id, ->(grade_id) { joins(:classroom).merge(Classroom.by_grade(grade_id)) }
   scope :frequency_date, ->(frequency_date) { where(frequency_date: frequency_date) }
   scope :frequency_date_between, ->(start_at, end_at) { where(frequency_date: start_at.to_date..end_at.to_date) }
   scope :by_teacher_id, lambda { |teacher_id|

--- a/app/presenters/daily_note_student_presenter.rb
+++ b/app/presenters/daily_note_student_presenter.rb
@@ -2,32 +2,32 @@ class DailyNoteStudentPresenter < BasePresenter
   def student_name_class
     name_class = 'multiline '
 
-    if exempted_from_discipline
-      name_class += 'exempted-student-from-discipline'
+    if in_active_search
+      name_class += 'in-active-search'
     elsif !active
       name_class += 'inactive-student'
     elsif exempted
       name_class += 'exempted-student'
     elsif dependence
       name_class += 'dependence-student'
-    elsif in_active_search
-      name_class += 'in-active-search'
+    elsif exempted_from_discipline
+      name_class += 'exempted-student-from-discipline'
     end
 
     name_class
   end
 
   def student_name
-    if exempted_from_discipline
-      "****#{student}"
+    if in_active_search
+      "*****#{student}"
     elsif !active
       "***#{student}"
     elsif exempted
       "**#{student}"
     elsif dependence
       "*#{student}"
-    elsif in_active_search
-      "*****#{student}"
+    elsif exempted_from_discipline
+      "****#{student}"
     else
       student.to_s
     end

--- a/app/queries/parent_dashboard_students_query.rb
+++ b/app/queries/parent_dashboard_students_query.rb
@@ -6,7 +6,7 @@ class ParentDashboardStudentsQuery
 
   def student_enrollment_classrooms
     StudentEnrollmentClassroom.joins(student_enrollment: { student: :users })
-                              .joins(:classroom)
+                              .joins(classrooms_grade: :classroom)
                               .by_date(date)
                               .where(User.arel_table[:id].eq(user.id))
                               .merge(StudentEnrollment.active)

--- a/app/reports/attendance_record_report.rb
+++ b/app/reports/attendance_record_report.rb
@@ -410,7 +410,7 @@ class AttendanceRecordReport < BaseReport
   end
 
   def classroom_has_general_absence?
-    classroom.exam_rule.try(:frequency_type) == FrequencyTypes::GENERAL
+    classroom.first_exam_rule.frequency_type == FrequencyTypes::GENERAL
   end
 
   def teacher_allow_absence_by_discipline?

--- a/app/reports/partial_score_record_report.rb
+++ b/app/reports/partial_score_record_report.rb
@@ -216,7 +216,7 @@ class PartialScoreRecordReport < BaseReport
   end
 
   def absences_count(student_id, discipline_id)
-    if @classroom.exam_rule.frequency_type == "2"
+    if @classroom.first_exam_rule.frequency_type == "2"
       DailyFrequencyStudent.general_by_classroom_discipline_student_date_between(
         @classroom.id, discipline_id, student_id, @school_calendar_step.start_at, @school_calendar_step.end_at
       ).absences.count

--- a/app/seeders/school_calendar_events_seeder.rb
+++ b/app/seeders/school_calendar_events_seeder.rb
@@ -9,13 +9,13 @@ class SchoolCalendarEventsSeeder
   def seed
     year = school_calendar.year.to_s
 
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Ano novo " + year, start_date: year + '-01-01', end_date: year + '-01-01', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Tiradentes", start_date: year + '-04-21', end_date: year + '-04-21', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Dia do trabalho", start_date: year + '-05-01', end_date: year + '-05-01', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Dia da independência", start_date: year + '-09-07', end_date: year + '-09-07', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Nossa Senhora Aparecida", start_date: year + '-10-12', end_date: year + '-10-12', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Finados", start_date: year + '-11-02', end_date: year + '-11-02', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Proclamação da República", start_date: year + '-11-15', end_date: year + '-11-15', event_type: EventTypes::NO_SCHOOL, legend: "E")
-    SchoolCalendarEvent.create!(school_calendar: school_calendar, description: "Feriado - Natal", start_date: year + '-12-25', end_date: year + '-12-25', event_type: EventTypes::NO_SCHOOL, legend: "E")
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Tiradentes", start_date: year + '-04-21', end_date: year + '-04-21', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Dia do trabalho", start_date: year + '-05-01', end_date: year + '-05-01', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Dia da independência", start_date: year + '-09-07', end_date: year + '-09-07', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Ano novo " + year, start_date: year + '-01-01', end_date: year + '-01-01', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Nossa Senhora Aparecida", start_date: year + '-10-12', end_date: year + '-10-12', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Finados", start_date: year + '-11-02', end_date: year + '-11-02', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Proclamação da República", start_date: year + '-11-15', end_date: year + '-11-15', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
+    SchoolCalendarEvent.new(school_calendar: school_calendar, description: "Feriado - Natal", start_date: year + '-12-25', end_date: year + '-12-25', event_type: EventTypes::NO_SCHOOL, legend: "E").save(validate: false)
   end
 end

--- a/app/services/absence_adjustments_service.rb
+++ b/app/services/absence_adjustments_service.rb
@@ -15,8 +15,8 @@ class AbsenceAdjustmentsService
   end
 
   def daily_frequencies_by_type(frequency_type)
-    daily_frequencies = DailyFrequency.joins(:classroom)
-                                      .merge(Classroom.joins(:exam_rule).where(exam_rules: { frequency_type: frequency_type }))
+    daily_frequencies = DailyFrequency.joins(classroom: [classrooms_grades: :exam_rule])
+                                      .where(exam_rules: { frequency_type: frequency_type })
                                       .where('extract(year from frequency_date) = ?', @year)
                                       .where(unity_id: @unity_ids)
 
@@ -28,9 +28,9 @@ class AbsenceAdjustmentsService
 
   def daily_frequencies_general_when_teacher_has_specific_area
     DailyFrequency
-      .joins(:classroom)
+      .joins(classroom: [classrooms_grades: :exam_rule])
       .joins('join teacher_discipline_classrooms on daily_frequencies.classroom_id = teacher_discipline_classrooms.classroom_id and daily_frequencies.owner_teacher_id = teacher_discipline_classrooms.teacher_id and teacher_discipline_classrooms.allow_absence_by_discipline = 1')
-      .merge(Classroom.joins(:exam_rule).where(exam_rules: { frequency_type: FrequencyTypes::GENERAL }))
+      .where(exam_rules: { frequency_type: FrequencyTypes::GENERAL })
       .where(discipline_id: nil)
       .where('extract(year from frequency_date) = ?', @year)
       .where(unity_id: @unity_ids)

--- a/app/services/complementary_exam_settings_fetcher.rb
+++ b/app/services/complementary_exam_settings_fetcher.rb
@@ -8,7 +8,7 @@ class ComplementaryExamSettingsFetcher
 
   def settings
     @complementary_exam_settings ||= ComplementaryExamSetting
-      .by_grade_id(@classroom.grade_id)
+      .by_grade_id(@classroom.grade_ids)
       .by_year(@classroom.year)
       .where(" NOT EXISTS (#{not_exists_condition})")
       .ordered

--- a/app/services/contents_for_discipline_record_fetcher.rb
+++ b/app/services/contents_for_discipline_record_fetcher.rb
@@ -18,7 +18,7 @@ class ContentsForDisciplineRecordFetcher < ContentsRecordFetcher
   def teaching_plans
     @teaching_plans ||= DisciplineTeachingPlan.includes(teaching_plan: :contents)
                                               .by_unity(@classroom.unity_id)
-                                              .by_grade(@classroom.grade_id)
+                                              .by_grade(@classroom.grade_ids)
                                               .by_discipline(@discipline.id)
                                               .by_year(school_calendar_year)
   end

--- a/app/services/contents_for_knowledge_area_record_fetcher.rb
+++ b/app/services/contents_for_knowledge_area_record_fetcher.rb
@@ -18,7 +18,7 @@ class ContentsForKnowledgeAreaRecordFetcher < ContentsRecordFetcher
   def teaching_plans
     @teaching_plans ||= KnowledgeAreaTeachingPlan.includes(teaching_plan: :contents)
                                                  .by_unity(@classroom.unity_id)
-                                                 .by_grade(@classroom.grade_id)
+                                                 .by_grade(@classroom.grade_ids)
                                                  .by_knowledge_area(@knowledge_areas.map(&:id))
                                                  .by_year(school_calendar_year)
   end

--- a/app/services/daily_note_creator.rb
+++ b/app/services/daily_note_creator.rb
@@ -34,6 +34,7 @@ class DailyNoteCreator
 
     @student_enrollments ||= StudentEnrollmentsList.new(
       classroom: @daily_note.classroom,
+      grade: @daily_note.avaliation.grade_ids,
       discipline: @daily_note.discipline,
       date: @daily_note.avaliation.test_date,
       score_type: StudentEnrollmentScoreTypeFilters::NUMERIC,

--- a/app/services/delete_dispensed_exams_and_frequencies_service.rb
+++ b/app/services/delete_dispensed_exams_and_frequencies_service.rb
@@ -15,7 +15,7 @@ class DeleteDispensedExamsAndFrequenciesService
 
   def remove_dispensed_exams_and_frequencies(student_enrollment)
     student_enrollment.student_enrollment_classrooms.each do |student_enrollment_classroom|
-      classroom = student_enrollment_classroom.classroom
+      classroom = student_enrollment_classroom.classrooms_grade.classroom
 
       next if classroom.blank?
 

--- a/app/services/delete_invalid_presence_record_service.rb
+++ b/app/services/delete_invalid_presence_record_service.rb
@@ -21,8 +21,10 @@ class DeleteInvalidPresenceRecordService
         SELECT 1
           FROM student_enrollments
           JOIN student_enrollment_classrooms
-            ON student_enrollment_classrooms.classroom_id = daily_frequencies.classroom_id
-           AND student_enrollment_classrooms.student_enrollment_id = student_enrollments.id
+            ON student_enrollment_classrooms.student_enrollment_id = student_enrollments.id
+          JOIN classrooms_grades
+            ON classrooms_grades.classroom_id = daily_frequencies.classroom_id
+           AND student_enrollment_classrooms.classrooms_grade_id = classrooms_grades.id
          WHERE student_enrollments.student_id = #{@student_id}
            AND daily_frequencies.frequency_date >= CAST(student_enrollment_classrooms.joined_at AS DATE)
            AND (

--- a/app/services/discipline_teaching_plan_contents_fetcher.rb
+++ b/app/services/discipline_teaching_plan_contents_fetcher.rb
@@ -12,7 +12,7 @@ class DisciplineTeachingPlanContentsFetcher < TeachingPlanContentsFetcher
   def base_query
     DisciplineTeachingPlan.includes(teaching_plan: :contents)
                           .by_unity(@classroom.unity_id)
-                          .by_grade(@classroom.grade_id)
+                          .by_grade(@classroom.grade_ids)
                           .by_discipline(@discipline.id)
                           .by_year(school_calendar_year)
                           .by_school_term_type_step_id(school_term_type_steps_ids)

--- a/app/services/discipline_teaching_plan_objectives_fetcher.rb
+++ b/app/services/discipline_teaching_plan_objectives_fetcher.rb
@@ -12,7 +12,7 @@ class DisciplineTeachingPlanObjectivesFetcher < TeachingPlanObjectivesFetcher
   def base_query
     DisciplineTeachingPlan.includes(teaching_plan: :objectives)
                           .by_unity(@classroom.unity_id)
-                          .by_grade(@classroom.grade_id)
+                          .by_grade(@classroom.grade_ids)
                           .by_discipline(@discipline.id)
                           .by_year(school_calendar_year)
                           .by_school_term_type_step_id(school_term_type_steps_ids)

--- a/app/services/exam_poster/absence_poster.rb
+++ b/app/services/exam_poster/absence_poster.rb
@@ -182,7 +182,7 @@ module ExamPoster
     end
 
     def classroom_frequency_by_discipline?(classroom)
-      classroom.exam_rule.frequency_type == FrequencyTypes::BY_DISCIPLINE
+      classroom.first_exam_rule.frequency_type == FrequencyTypes::BY_DISCIPLINE
     end
   end
 end

--- a/app/services/exam_poster/descriptive_exam_poster.rb
+++ b/app/services/exam_poster/descriptive_exam_poster.rb
@@ -110,8 +110,8 @@ module ExamPoster
         exams.each do |exam|
           next if exam.student.nil?
           next unless valid_opinion_type?(
-            exam.student.try(:uses_differentiated_exam_rule),
-            OpinionTypes::BY_STEP, classroom.exam_rule
+            exam.student.uses_differentiated_exam_rule,
+            OpinionTypes::BY_STEP, classroom.first_exam_rule
           )
 
           descriptive_exams[classroom.api_code][exam.student.api_code]['valor'] = exam.value
@@ -133,8 +133,8 @@ module ExamPoster
         exams.each do |exam|
           next if exam.student.nil?
           next unless valid_opinion_type?(
-            exam.student.try(:uses_differentiated_exam_rule),
-            OpinionTypes::BY_YEAR, classroom.exam_rule
+            exam.student.uses_differentiated_exam_rule,
+            OpinionTypes::BY_YEAR, classroom.first_exam_rule
           )
 
           descriptive_exams[classroom.api_code][exam.student.api_code]['valor'] = exam.value
@@ -164,7 +164,7 @@ module ExamPoster
           next unless valid_opinion_type?(
             exam.student.try(:uses_differentiated_exam_rule),
             OpinionTypes::BY_YEAR_AND_DISCIPLINE,
-            classroom.exam_rule
+            classroom.first_exam_rule
           )
 
           descriptive_exams[classroom.api_code][exam.student.api_code][discipline.api_code]['valor'] = exam.value
@@ -202,7 +202,7 @@ module ExamPoster
           next unless valid_opinion_type?(
             exam.student.try(:uses_differentiated_exam_rule),
             OpinionTypes::BY_STEP_AND_DISCIPLINE,
-            classroom.exam_rule
+            classroom.first_exam_rule
           )
 
           descriptive_exams[classroom.api_code][exam.student.api_code][discipline.api_code]['valor'] = exam.value

--- a/app/services/exam_poster/final_recovery_poster.rb
+++ b/app/services/exam_poster/final_recovery_poster.rb
@@ -87,12 +87,14 @@ module ExamPoster
     def teacher_discipline_classrooms
       teacher.teacher_discipline_classrooms.select do |teacher_discipline_classroom|
         can_post?(teacher_discipline_classroom.classroom) &&
-          valid_score_type?(teacher_discipline_classroom.classroom.exam_rule.score_type)
+          valid_score_type?(teacher_discipline_classroom.classroom)
       end
     end
 
-    def valid_score_type?(score_type)
-      [ScoreTypes::NUMERIC, ScoreTypes::NUMERIC_AND_CONCEPT].include?(score_type)
+    def valid_score_type?(classroom)
+      classroom.classrooms_grades.any? { |classroom_grade|
+        [ScoreTypes::NUMERIC, ScoreTypes::NUMERIC_AND_CONCEPT].include?(classroom_grade.exam_rule.score_type)
+      }
     end
   end
 end

--- a/app/services/exam_poster/numerical_exam_poster.rb
+++ b/app/services/exam_poster/numerical_exam_poster.rb
@@ -34,7 +34,9 @@ module ExamPoster
                                                                 .by_classroom(classroom)
                                                                 .by_date(Date.current)
                                                                 .first
-      grade_id = student_enrrollment_classroom.classrooms_grade.grade_id
+      return if student_enrrollment_classroom.nil?
+
+      grade_id = student_enrrollment_classroom.classrooms_grade&.grade_id
       classroom.classrooms_grades.find_by(grade_id: grade_id).exam_rule
     end
 
@@ -97,7 +99,7 @@ module ExamPoster
     def correct_score_type(differentiated, exam_rule)
       exam_rule = (exam_rule.differentiated_exam_rule || exam_rule) if differentiated
       score_types = [ScoreTypes::NUMERIC, ScoreTypes::NUMERIC_AND_CONCEPT]
-      score_types.include? exam_rule.score_type
+      score_types.include? exam_rule&.score_type
     end
 
     def fetch_school_term_recovery_score(classroom, discipline, student)

--- a/app/services/exam_poster/numerical_exam_poster.rb
+++ b/app/services/exam_poster/numerical_exam_poster.rb
@@ -29,6 +29,15 @@ module ExamPoster
       end
     end
 
+    def exam_rule_definer(classroom, student)
+      student_enrrollment_classroom = StudentEnrollmentClassroom.by_student(student)
+                                                                .by_classroom(classroom)
+                                                                .by_date(Date.current)
+                                                                .first
+      grade_id = student_enrrollment_classroom.classrooms_grade.grade_id
+      classroom.classrooms_grades.find_by(grade_id: grade_id).exam_rule
+    end
+
     def post_by_classrooms
       scores = Hash.new { |hash, key| hash[key] = Hash.new(&hash.default_proc) }
       classroom_ids = teacher.teacher_discipline_classrooms.pluck(:classroom_id).uniq.compact
@@ -56,8 +65,10 @@ module ExamPoster
           student_scores = teacher_score_fetcher.scores
 
           student_scores.each do |student_score|
+            exam_rule = exam_rule_definer(classroom, student_score)
             next if exempted_discipline(classroom, discipline.id, student_score.id)
-            next unless correct_score_type(student_score.uses_differentiated_exam_rule, classroom.exam_rule)
+            next unless correct_score_type(student_score.uses_differentiated_exam_rule,
+                                           exam_rule)
 
             exempted_discipline_ids =
               ExemptedDisciplinesInStep.discipline_ids(classroom.id, get_step(classroom).to_number)

--- a/app/services/exam_poster/numerical_exam_poster.rb
+++ b/app/services/exam_poster/numerical_exam_poster.rb
@@ -97,6 +97,8 @@ module ExamPoster
     end
 
     def correct_score_type(differentiated, exam_rule)
+      return if exam_rule.nil?
+
       exam_rule = (exam_rule.differentiated_exam_rule || exam_rule) if differentiated
       score_types = [ScoreTypes::NUMERIC, ScoreTypes::NUMERIC_AND_CONCEPT]
       score_types.include? exam_rule&.score_type

--- a/app/services/exam_rule_fetcher.rb
+++ b/app/services/exam_rule_fetcher.rb
@@ -9,11 +9,21 @@ class ExamRuleFetcher
   end
 
   def fetch
-    return nil unless @classroom.exam_rule.present?
+    return if @classroom.classrooms_grades.none? { |classroom_grade| classroom_grade.exam_rule.present? }
+
+    student_enrrollment_classroom = StudentEnrollmentClassroom.by_student(@student)
+                                                              .by_classroom(@classroom)
+                                                              .by_date(Date.current)
+                                                              &.first
+    return if student_enrrollment_classroom.blank?
+
+    grade_id = student_enrrollment_classroom.classrooms_grade.grade_id
+    classroom_grade = @classroom.classrooms_grades.find_by(grade_id: grade_id)
+
     if @student.uses_differentiated_exam_rule
-      (@classroom.exam_rule.differentiated_exam_rule || @classroom.exam_rule)
+      (classroom_grade.exam_rule.differentiated_exam_rule || classroom_grade.exam_rule)
     else
-      @classroom.exam_rule
+      classroom_grade.exam_rule
     end
   end
 end

--- a/app/services/features_access_levels.rb
+++ b/app/services/features_access_levels.rb
@@ -43,7 +43,8 @@ class FeaturesAccessLevels
       :complementary_exams,
       :ieducar_api_exam_posting_without_restrictions,
       :change_school_year,
-      :daily_frequencies_in_batchs
+      :daily_frequencies_in_batchs,
+      :learning_objectives_and_skills
     ]
   end
 
@@ -73,8 +74,7 @@ class FeaturesAccessLevels
       :roles,
       :unities,
       :terms_dictionaries,
-      :translations,
-      :learning_objectives_and_skills
+      :translations
     ]
   end
 end

--- a/app/services/frequency_type_definer.rb
+++ b/app/services/frequency_type_definer.rb
@@ -4,7 +4,7 @@ class FrequencyTypeDefiner
   def initialize(classroom, teacher, exam_rule = nil, year: nil)
     @classroom = classroom
     @teacher = teacher
-    @exam_rule = exam_rule || classroom.try(:exam_rule)
+    @exam_rule = exam_rule || classroom.classrooms_grades.first.try(:exam_rule)
     @year = year
   end
 

--- a/app/services/ieducar_api/school_calendar_discipline_grades.rb
+++ b/app/services/ieducar_api/school_calendar_discipline_grades.rb
@@ -1,0 +1,13 @@
+module IeducarApi
+  class SchoolCalendarDisciplineGrades < Base
+    def fetch(params = {})
+      params.reverse_merge!(
+        path: 'module/Api/Escola',
+        resource: 'escola-serie-disciplinas-anos-letivos'
+      )
+      raise ApiError, 'É necessário informar pelo menos uma escola' if params[:escola].blank?
+
+      super
+    end
+  end
+end

--- a/app/services/ieducar_synchronizers/active_search_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/active_search_synchronizer.rb
@@ -2,15 +2,18 @@ class ActiveSearchSynchronizer
   include Sidekiq::Worker
 
   def perform(student_enrollment_id, active_search_record)
-    active_search = ActiveSearch.find_or_initialize_by(student_enrollment_id: student_enrollment_id)
-    active_search.start_date = active_search_record.data_inicio
-    active_search.end_date = active_search_record.data_fim
-    active_search.status = active_search_record.resultado_busca_ativa
-    active_search.observations = active_search_record.observacoes
+    ActiveSearch.find_or_initialize_by(student_enrollment_id: student_enrollment_id).tap do |active_search|
+      active_search.api_code = active_search_record.id
+      active_search.start_date = active_search_record.data_inicio
+      active_search.end_date = active_search_record.data_fim
+      active_search.status = active_search_record.resultado_busca_ativa
+      active_search.observations = active_search_record.observacoes
 
-    active_search.save! if active_search.changed?
+      active_search.save! if active_search.changed?
 
-    ActiveSearchService.new(active_search).daily_note
+      active_search.discard_or_undiscard(active_search_record.deleted_at.present?)
 
+      ActiveSearchService.new(active_search).daily_note
+    end
   end
 end

--- a/app/services/ieducar_synchronizers/classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/classrooms_synchronizer.rb
@@ -49,7 +49,10 @@ class ClassroomsSynchronizer < BaseSynchronizer
 
           grades_ids << grade.id
 
-          classroom.classrooms_grades.find_or_initialize_by(grade_id: grade.id)
+          classroom.classrooms_grades.find_or_initialize_by(grade_id: grade.id).tap do |classroom_grade|
+            classroom_grade.exam_rule_id = exam_rule.id
+            classroom_grade.save!
+          end
         end
 
         destroy_old_grades(grades_ids, classroom.classrooms_grades)

--- a/app/services/ieducar_synchronizers/classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/classrooms_synchronizer.rb
@@ -22,7 +22,9 @@ class ClassroomsSynchronizer < BaseSynchronizer
 
       next if unity.blank?
 
-      grade = grade(classroom_record.serie_id)
+      grades = []
+      classroom_record.series_regras.select { |serie| grades << serie.serie_id }
+      grade = grade(grades.compact.first)
 
       next if grade.blank?
 
@@ -35,15 +37,21 @@ class ClassroomsSynchronizer < BaseSynchronizer
         classroom.unity = unity
         classroom.unity_code = classroom_record.escola_id
         classroom.period = classroom_record.turno_id
-        classroom.grade = grade
         classroom.year = classroom_record.ano
-        classroom.exam_rule_id = exam_rule(classroom_record.regra_avaliacao_id).try(:id)
+        classroom_record.series_regras.each do |grade_exam_rule|
+          grade = grade(grade_exam_rule.serie_id)
+          exam_rule = exam_rule(grade_exam_rule.regra_avaliacao_id)
+
+          next if grade.blank? || exam_rule.blank?
+
+          classroom.classrooms_grades.find_or_initialize_by(grade_id: grade.id, exam_rule_id: exam_rule.id)
+        end
 
         if classroom.persisted? && classroom.period_changed? && classroom.period_was.present?
           update_period_dependents(classroom.id, classroom.period_was, classroom.period)
         end
 
-        classroom.save! if classroom.changed?
+        classroom.save!
 
         update_label(classroom.id, new_name) if old_name != new_name
 

--- a/app/services/ieducar_synchronizers/grade_exam_rules_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/grade_exam_rules_synchronizer.rb
@@ -24,15 +24,16 @@ class GradeExamRulesSynchronizer < BaseSynchronizer
 
       exam_rule = exam_rule(grade_exam_rule.regra_avaliacao_id)
       differentiated_exam_rule = exam_rule(grade_exam_rule.regra_avaliacao_diferenciada_id)
+      classrooms_grades = ClassroomsGrade.by_grade_id(grade.id).by_year(year).by_exam_rule(exam_rule.id)
 
-      grade.classrooms.with_discarded.by_year(year).each do |classroom_record|
-        classroom_record.tap do |classroom|
-          unity = unity(classroom.unity_code)
-          current_exam_rule = differentiated_exam_rule if unity.try(:uses_differentiated_exam_rule?)
-          current_exam_rule ||= exam_rule
-          classroom.exam_rule = current_exam_rule
-          classroom.save! if classroom.changed?
-        end
+      classrooms_grades.each do |classroom_grade|
+        unity = unity(classroom_grade.classroom.unity_code)
+
+        current_exam_rule = differentiated_exam_rule if unity.try(:uses_differentiated_exam_rule?)
+        current_exam_rule ||= exam_rule
+        classroom_grade.exam_rule = current_exam_rule
+
+        classroom_grade.save! if classroom_grade.changed?
       end
     end
   end

--- a/app/services/ieducar_synchronizers/school_calendar_discipline_grades_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/school_calendar_discipline_grades_synchronizer.rb
@@ -1,0 +1,64 @@
+class SchoolCalendarDisciplineGradesSynchronizer < BaseSynchronizer
+  def synchronize!
+    update_school_calendar_discipline_grade(
+      HashDecorator.new(
+        api.fetch(
+          escola: unity_api_code
+        )['escolas']
+      )
+    )
+  end
+
+  private
+
+  def api_class
+    IeducarApi::SchoolCalendarDisciplineGrades
+  end
+
+  def update_school_calendar_discipline_grade(unity_grade_discipline_years)
+    existing_school_calendar_discipline_grade = []
+
+    unity_grade_discipline_years.each do |unity_grade_discipline_year_record|
+      @unity = unity(unity_grade_discipline_year_record.escola_id)
+
+      next if @unity.blank?
+
+      unity_grade_discipline_year_record.series_disciplinas_anos_letivos.each do |grade_discipline_year|
+        grade = grade(grade_discipline_year.serie_id)
+
+        next if grade.blank?
+
+        grade_discipline_year.disciplinas_anos_letivos.each do |discipline_and_years|
+          discipline_api_code = discipline_and_years.to_h.keys.first.to_s
+          years = discipline_and_years.to_h.values.flatten
+          discipline = discipline(discipline_api_code)
+
+          next if discipline.blank?
+
+          years.each do |year|
+            school_calendar = SchoolCalendar.find_by(year: year, unity: @unity)
+
+            next if school_calendar.blank?
+
+            school_calendar_discipline_grade = SchoolCalendarDisciplineGrade.find_or_create_by(
+              school_calendar_id: school_calendar.id,
+              discipline_id: discipline.id,
+              grade_id: grade.id
+            )
+
+            existing_school_calendar_discipline_grade << school_calendar_discipline_grade.try(:id)
+          end
+        end
+      end
+    end
+
+    destroy_removed_disciplines(existing_school_calendar_discipline_grade)
+  end
+
+  def destroy_removed_disciplines(existing_school_calendar_discipline_grade)
+    return if @unity.nil?
+
+    SchoolCalendarDisciplineGrade.where.not(id: existing_school_calendar_discipline_grade).joins(:school_calendar)
+                                 .where(school_calendars: { unity_id: @unity.try(:id) }).destroy_all
+  end
+end

--- a/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
@@ -25,8 +25,15 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
       classroom_id = classroom(student_enrollment_classroom_record.turma_id).try(:id)
       grade_id = grade(student_enrollment_classroom_record.serie_id).try(:id)
       student_enrollment = student_enrollment(student_enrollment_classroom_record.matricula_id)
+      student_enrollment_classroom = StudentEnrollmentClassroom.find_by(
+        api_code: student_enrollment_classroom_record.id
+      )
 
-      next if student_enrollment.blank?
+      if student_enrollment.blank?
+        student_enrollment_classroom.discard if student_enrollment_classroom
+
+        next
+      end
 
       StudentEnrollmentClassroom.with_discarded.find_or_initialize_by(
         api_code: student_enrollment_classroom_record.id

--- a/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
@@ -23,6 +23,7 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
 
     student_enrollment_classrooms.each do |student_enrollment_classroom_record|
       classroom_id = classroom(student_enrollment_classroom_record.turma_id).try(:id)
+      grade_id = grade(student_enrollment_classroom_record.serie_id).try(:id)
       student_enrollment = student_enrollment(student_enrollment_classroom_record.matricula_id)
 
       next if student_enrollment.blank?
@@ -31,7 +32,8 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
         api_code: student_enrollment_classroom_record.id
       ).tap do |student_enrollment_classroom|
         student_enrollment_classroom.student_enrollment = student_enrollment
-        student_enrollment_classroom.classroom_id = classroom_id
+        student_enrollment_classroom.classrooms_grade_id = ClassroomsGrade.find_by(classroom_id: classroom_id,
+                                                                                   grade_id: grade_id).try(:id)
         student_enrollment_classroom.classroom_code = student_enrollment_classroom_record.turma_id
         student_enrollment_classroom.joined_at = student_enrollment_classroom_record.data_entrada
         student_enrollment_classroom.left_at = student_enrollment_classroom_record.data_saida
@@ -56,7 +58,7 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
     delete_invalid_presence_records(changed_student_enrollment_classrooms)
   end
 
-  def delete_invalid_presence_records(changed_student_enrollment_classrooms)
+  def   delete_invalid_presence_records(changed_student_enrollment_classrooms)
     changed_student_enrollment_classrooms.uniq.each do |student_id, classroom_id|
       next if student_id.blank? || classroom_id.blank?
 

--- a/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
@@ -38,7 +38,7 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
         student_enrollment_classroom.joined_at = student_enrollment_classroom_record.data_entrada
         student_enrollment_classroom.left_at = student_enrollment_classroom_record.data_saida
         student_enrollment_classroom.changed_at = student_enrollment_classroom_record.updated_at
-        student_enrollment_classroom.sequence = student_enrollment_classroom_record.sequencial_fechamento
+        student_enrollment_classroom.sequence = business.generate_sequence(student_enrollment, student_enrollment_classroom, student_enrollment_classroom_record)
         student_enrollment_classroom.index = student_enrollment_classroom_record.sequencial
         student_enrollment_classroom.show_as_inactive_when_not_in_date =
           student_enrollment_classroom_record.apresentar_fora_da_data
@@ -58,7 +58,11 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
     delete_invalid_presence_records(changed_student_enrollment_classrooms)
   end
 
-  def   delete_invalid_presence_records(changed_student_enrollment_classrooms)
+  def business
+    @object ||= StudentEnrollmentClassroomBusinesses.new
+  end
+
+  def delete_invalid_presence_records(changed_student_enrollment_classrooms)
     changed_student_enrollment_classrooms.uniq.each do |student_id, classroom_id|
       next if student_id.blank? || classroom_id.blank?
 

--- a/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/student_enrollment_classroom_synchronizer.rb
@@ -38,7 +38,11 @@ class StudentEnrollmentClassroomSynchronizer < BaseSynchronizer
         student_enrollment_classroom.joined_at = student_enrollment_classroom_record.data_entrada
         student_enrollment_classroom.left_at = student_enrollment_classroom_record.data_saida
         student_enrollment_classroom.changed_at = student_enrollment_classroom_record.updated_at
-        student_enrollment_classroom.sequence = business.generate_sequence(student_enrollment, student_enrollment_classroom, student_enrollment_classroom_record)
+
+        if student_enrollment_classroom_record.deleted_at.nil?
+          student_enrollment_classroom.sequence = business.generate_sequence(student_enrollment, student_enrollment_classroom, student_enrollment_classroom_record)
+        end
+
         student_enrollment_classroom.index = student_enrollment_classroom_record.sequencial
         student_enrollment_classroom.show_as_inactive_when_not_in_date =
           student_enrollment_classroom_record.apresentar_fora_da_data

--- a/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
@@ -62,12 +62,7 @@ class TeacherDisciplineClassroomsSynchronizer < BaseSynchronizer
     return if discipline_id.blank?
 
     teacher_discipline_classrooms = TeacherDisciplineClassroom.unscoped.where(
-      api_code: teacher_discipline_classroom_record.id,
-      year: year,
-      teacher_id: teacher_id,
-      teacher_api_code: teacher_discipline_classroom_record.servidor_id,
-      discipline_id: discipline_id,
-      discipline_api_code: discipline_api_code
+      api_code: teacher_discipline_classroom_record.id
     )
 
     teacher_discipline_classroom =

--- a/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
@@ -62,7 +62,9 @@ class TeacherDisciplineClassroomsSynchronizer < BaseSynchronizer
     return if discipline_id.blank?
 
     teacher_discipline_classrooms = TeacherDisciplineClassroom.unscoped.where(
-      api_code: teacher_discipline_classroom_record.id
+      api_code: teacher_discipline_classroom_record.id,
+      year: year,
+      discipline_id: discipline_id
     )
 
     teacher_discipline_classroom =
@@ -102,7 +104,8 @@ class TeacherDisciplineClassroomsSynchronizer < BaseSynchronizer
 
   def teacher_discipline_classrooms_to_discard(teacher_discipline_classroom_record, existing_discipline_api_codes)
     teacher_discipline_classrooms = TeacherDisciplineClassroom.unscoped.where(
-      api_code: teacher_discipline_classroom_record.id
+      api_code: teacher_discipline_classroom_record.id,
+      year: year
     )
 
     return teacher_discipline_classrooms if teacher_discipline_classroom_record.deleted_at.present?

--- a/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/teacher_discipline_classrooms_synchronizer.rb
@@ -64,7 +64,8 @@ class TeacherDisciplineClassroomsSynchronizer < BaseSynchronizer
     teacher_discipline_classrooms = TeacherDisciplineClassroom.unscoped.where(
       api_code: teacher_discipline_classroom_record.id,
       year: year,
-      discipline_id: discipline_id
+      discipline_id: discipline_id,
+      discipline_api_code: discipline_api_code
     )
 
     teacher_discipline_classroom =
@@ -108,9 +109,12 @@ class TeacherDisciplineClassroomsSynchronizer < BaseSynchronizer
       year: year
     )
 
+    existing_disciplines_ids = Discipline.where(api_code: existing_discipline_api_codes)
+                                         .pluck(:id)
+
     return teacher_discipline_classrooms if teacher_discipline_classroom_record.deleted_at.present?
 
-    teacher_discipline_classrooms.where.not(discipline_api_code: existing_discipline_api_codes)
+    teacher_discipline_classrooms.where.not(discipline_id: existing_disciplines_ids)
   end
 
   def create_empty_conceptual_exam_value(teacher_discipline_classroom_record)

--- a/app/services/infrequency_tracking_notifier.rb
+++ b/app/services/infrequency_tracking_notifier.rb
@@ -67,7 +67,7 @@ class InfrequencyTrackingNotifier
     days = general_configuration.days_to_consider_alternate_absences
 
     SchoolDayChecker.new(
-      school_calendar(classroom), end_at, classroom.grade_id, classroom.id, nil
+      school_calendar(classroom), end_at, classroom.grade_ids, classroom.id, nil
     ).school_dates_since(
       end_at, days
     ).sort

--- a/app/services/knowledge_area_teaching_plan_contents_fetcher.rb
+++ b/app/services/knowledge_area_teaching_plan_contents_fetcher.rb
@@ -12,7 +12,7 @@ class KnowledgeAreaTeachingPlanContentsFetcher < TeachingPlanContentsFetcher
   def base_query
     KnowledgeAreaTeachingPlan.includes(teaching_plan: :contents)
                              .by_unity(@classroom.unity_id)
-                             .by_grade(@classroom.grade_id)
+                             .by_grade(@classroom.grade_ids)
                              .by_knowledge_area(@knowledge_area_ids)
                              .by_year(school_calendar_year)
                              .by_school_term_type_step_id(school_term_type_steps_ids)

--- a/app/services/knowledge_area_teaching_plan_objectives_fetcher.rb
+++ b/app/services/knowledge_area_teaching_plan_objectives_fetcher.rb
@@ -12,7 +12,7 @@ class KnowledgeAreaTeachingPlanObjectivesFetcher < TeachingPlanObjectivesFetcher
   def base_query
     KnowledgeAreaTeachingPlan.includes(teaching_plan: :objectives)
                              .by_unity(@classroom.unity_id)
-                             .by_grade(@classroom.grade_id)
+                             .by_grade(@classroom.grade_ids)
                              .by_knowledge_area(@knowledge_area_ids)
                              .by_year(school_calendar_year)
                              .by_school_term_type_step_id(school_term_type_steps_ids)

--- a/app/services/lesson_boards_fetcher.rb
+++ b/app/services/lesson_boards_fetcher.rb
@@ -5,7 +5,7 @@ class LessonBoardsFetcher
 
   def lesson_boards
     @lesson_boards = LessonsBoard.by_unity(unities)
-    @lesson_boards.joins(:classroom).order('classrooms.description')
+    @lesson_boards.joins(classrooms_grade: :classroom).order('classrooms.description')
   end
 
   def unities

--- a/app/services/recovery_steps_fetcher.rb
+++ b/app/services/recovery_steps_fetcher.rb
@@ -25,11 +25,11 @@ class RecoveryStepsFetcher
   end
 
   def recovery_type
-    @classroom.exam_rule.recovery_type
+    @classroom.first_exam_rule.recovery_type
   end
 
   def recovery_exam_rule
-    @classroom.exam_rule.recovery_exam_rules.find do |recovery_diary_record|
+    @classroom.first_exam_rule.recovery_exam_rules.find do |recovery_diary_record|
       recovery_diary_record.steps.last.eql?(@step.to_number)
     end
   end

--- a/app/services/school_term_average_calculator.rb
+++ b/app/services/school_term_average_calculator.rb
@@ -26,10 +26,10 @@ class SchoolTermAverageCalculator
   end
 
   def calculate_average?
-    classroom.exam_rule.try(:calculate_school_term_average?)
+    classroom.first_exam_rule.try(:calculate_school_term_average?)
   end
 
   def calculate_sum?
-    classroom.exam_rule.try(:calculate_school_term_sum?)
+    classroom.first_exam_rule.try(:calculate_school_term_sum?)
   end
 end

--- a/app/services/score_rounder.rb
+++ b/app/services/score_rounder.rb
@@ -51,7 +51,7 @@ class ScoreRounder
   def custom_rounding_table_id
     CustomRoundingTable.by_year(@classroom.year)
                        .by_unity(@classroom.unity_id)
-                       .by_grade(@classroom.grade_id)
+                       .by_grade(@classroom.grade_ids)
                        .by_avaliation(@rounded_avaliation)
                        .first.try(:id)
   end

--- a/app/services/student_enrollment_classroom_businesses.rb
+++ b/app/services/student_enrollment_classroom_businesses.rb
@@ -1,0 +1,35 @@
+class StudentEnrollmentClassroomBusinesses
+
+  attr_accessor :year
+
+  def generate_sequence(student_enrollment, student_enrollment_classroom, student_enrollment_classroom_record)
+    self.year = student_enrollment_classroom&.classrooms_grade&.year
+    sequencial_fechamento = student_enrollment_classroom_record.sequencial_fechamento
+    student_enrollment_last = student_enrollment_last(student_enrollment)
+    return sequencial_fechamento if student_enrollment_last.nil?
+
+    new_sequence(sequencial_fechamento, student_enrollment_classroom, student_enrollment_last)
+  end
+
+  private
+
+  def new_sequence(sequencial_fechamento, student_enrollment_classroom, student_enrollment_last)
+    classroom_ids = student_enrollment_last.student_enrollment_classrooms.map { |student_enrollment_classroom|
+      student_enrollment_classroom&.classrooms_grade&.classroom_id
+    }
+
+    if same_enrollment_classroom?(classroom_ids) || student_enrollment_classroom
+      student_enrollment_classroom.sequence
+    else
+      sequencial_fechamento
+    end
+  end
+
+  def same_enrollment_classroom?(classroom_ids)
+    classroom_ids.last(2).count.eql?(2) && classroom_ids.last(2).uniq.count.eql?(1)
+  end
+
+  def student_enrollment_last(student_enrollment)
+    StudentEnrollment.active.by_year(year).by_student(student_enrollment.student.try(:id)).last
+  end
+end

--- a/app/services/student_enrollments_list.rb
+++ b/app/services/student_enrollments_list.rb
@@ -5,6 +5,7 @@ class StudentEnrollmentsList
 
   def initialize(params)
     @classroom = params.fetch(:classroom)
+    @grade = params.fetch(:grade, nil)
     @discipline = params.fetch(:discipline)
     @date = params.fetch(:date, nil)
     @start_at = params.fetch(:start_at, nil)
@@ -35,7 +36,7 @@ class StudentEnrollmentsList
 
   attr_accessor :classroom, :discipline, :year, :date, :start_at, :end_at, :search_type, :show_inactive,
                 :show_inactive_outside_step, :score_type, :opinion_type, :with_recovery_note_in_step,
-                :include_date_range, :period
+                :include_date_range, :period, :grade
 
   def ensure_has_valid_params
     if search_type == :by_date
@@ -53,6 +54,8 @@ class StudentEnrollmentsList
                                               .includes(:student)
                                               .includes(:dependences)
                                               .active
+
+    students_enrollments = students_enrollments.by_grade(grade) if grade
 
     if include_date_range
       students_enrollments = students_enrollments.includes(:student_enrollment_classrooms)

--- a/app/services/student_recovery_average_calculator.rb
+++ b/app/services/student_recovery_average_calculator.rb
@@ -17,7 +17,7 @@ class StudentRecoveryAverageCalculator
   attr_accessor :student, :classroom, :discipline, :step
 
   def exam_rule
-    classroom.exam_rule
+    classroom.first_exam_rule
   end
 
   def steps_fetcher

--- a/app/services/students_in_recovery_fetcher.rb
+++ b/app/services/students_in_recovery_fetcher.rb
@@ -10,12 +10,12 @@ class StudentsInRecoveryFetcher
   def fetch
     @students = []
 
-    if (classroom.exam_rule.differentiated_exam_rule.blank? ||
-        classroom.exam_rule.differentiated_exam_rule.recovery_type == classroom.exam_rule.recovery_type)
-      @students += fetch_by_recovery_type(classroom.exam_rule.recovery_type)
+    if (classroom.first_exam_rule.differentiated_exam_rule.blank? ||
+        classroom.first_exam_rule.differentiated_exam_rule.recovery_type == classroom.first_exam_rule.recovery_type)
+      @students += fetch_by_recovery_type(classroom.first_exam_rule.recovery_type)
     else
-      @students += fetch_by_recovery_type(classroom.exam_rule.recovery_type, false)
-      @students += fetch_by_recovery_type(classroom.exam_rule.differentiated_exam_rule.recovery_type, true)
+      @students += fetch_by_recovery_type(classroom.first_exam_rule.recovery_type, false)
+      @students += fetch_by_recovery_type(classroom.first_exam_rule.differentiated_exam_rule.recovery_type, true)
     end
 
     @students.uniq!
@@ -71,10 +71,10 @@ class StudentsInRecoveryFetcher
   def fetch_students_in_parallel_recovery(differentiated = nil)
     students = enrollment_students
 
-    if classroom.exam_rule.parallel_recovery_average
+    if classroom.first_exam_rule.parallel_recovery_average
       students = students.select { |student|
         if (average = student.average(classroom, discipline, step))
-          average < classroom.exam_rule.parallel_recovery_average
+          average < classroom.first_exam_rule.parallel_recovery_average
         end
       }
     end
@@ -87,7 +87,7 @@ class StudentsInRecoveryFetcher
 
     recovery_steps = RecoveryStepsFetcher.new(step, classroom).fetch
 
-    recovery_exam_rule = classroom.exam_rule.recovery_exam_rules.find { |recovery_diary_record|
+    recovery_exam_rule = classroom.first_exam_rule.recovery_exam_rules.find { |recovery_diary_record|
       recovery_diary_record.steps.last.eql?(@step.to_number)
     }
 

--- a/app/services/test_setting_fetcher.rb
+++ b/app/services/test_setting_fetcher.rb
@@ -57,7 +57,7 @@ class TestSettingFetcher
   def general_by_school_test_setting
     TestSetting.where(year: @year, exam_setting_type: ExamSettingTypes::GENERAL_BY_SCHOOL)
                .by_unities(@classroom.unity)
-               .where("grades @> ARRAY[?]::integer[] OR grades = '{}'", @classroom.grade)
+               .where("grades && ARRAY[?]::integer[] OR grades = '{}'", @classroom.grade_ids)
                .first
   end
 

--- a/app/services/user_for_student_creator.rb
+++ b/app/services/user_for_student_creator.rb
@@ -38,15 +38,10 @@ class UserForStudentCreator
       user.password = password
       user.password_confirmation = password
       user.status = UserStatus::ACTIVE
-      user.save!
-
-      user_role = UserRole.create!(
-        user_id: user.id,
-        role_id: role_id
-      )
-
-      user.current_user_role_id = user_role.id
-      user.save!(validate: false)
+      user.user_roles.build(role_id: role_id)
+      user.without_auditing do
+        user.save!(validate: false)
+      end
     end
   end
 end

--- a/app/services/years_from_student_fetcher.rb
+++ b/app/services/years_from_student_fetcher.rb
@@ -1,13 +1,13 @@
 class YearsFromStudentFetcher
   def fetch(student_id)
-    student_enrollment_classrooms = StudentEnrollmentClassroom.by_student(student_id).includes(:classroom)
+    student_enrollment_classrooms = StudentEnrollmentClassroom.by_student(student_id).includes(:classrooms_grade)
+
     return if student_enrollment_classrooms.nil?
 
     years = student_enrollment_classrooms.map { |student_enrollment_classroom|
-      next if student_enrollment_classroom.classroom.nil?
-
-      student_enrollment_classroom.classroom.year
+      student_enrollment_classroom.classrooms_grade.classroom.year
     }
+
     years.compact.uniq.sort.reverse
   end
 

--- a/app/services/years_from_student_fetcher.rb
+++ b/app/services/years_from_student_fetcher.rb
@@ -5,7 +5,7 @@ class YearsFromStudentFetcher
     return if student_enrollment_classrooms.nil?
 
     years = student_enrollment_classrooms.map { |student_enrollment_classroom|
-      student_enrollment_classroom.classrooms_grade.classroom.year
+      student_enrollment_classroom&.classrooms_grade&.classroom&.year
     }
 
     years.compact.uniq.sort.reverse

--- a/app/validators/school_calendar_day_validator.rb
+++ b/app/validators/school_calendar_day_validator.rb
@@ -2,11 +2,21 @@ class SchoolCalendarDayValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return unless value && record.school_calendar
 
-    unless record.school_calendar.school_day?(value, record.try(:classroom).try(:grade).try(:id), record.try(:classroom).try(:id), record.try(:discipline).try(:id))
+    classroom_id = record.try(:classroom).try(:id)
+    grade_ids = record.try(:grade_ids) || record.try(:classroom).try(:grades)&.pluck(:id)
+    discipline_id = record.try(:discipline).try(:id)
+    school_day = true
+    message = ''
+
+    loop do
+      grade_id = grade_ids&.shift
+      school_day = false unless record.school_calendar.school_day?(value, grade_id, classroom_id, discipline_id)
       step = record.school_calendar.steps.posting_date_after_and_before(value).first
       message = step ? I18n.t('errors.messages.not_school_calendar_day') : I18n.t('errors.messages.is_not_between_steps')
 
-      record.errors.add(attribute, message)
+      break if grade_ids.blank? || !school_day
     end
+
+    record.errors.add(attribute, message) unless school_day
   end
 end

--- a/app/views/api/v2/content_records/index.json.jbuilder
+++ b/app/views/api/v2/content_records/index.json.jbuilder
@@ -18,7 +18,7 @@ json.content_records @content_records do |content_record|
   end
   json.knowledge_areas knowledge_areas
   json.discipline_id discipline_id
-  json.grade_id content_record.grade_id
+  json.grade_id content_record.first_grade.id
 
   json.record_date content_record.record_date
 end

--- a/app/views/api/v2/content_records/lesson_plans.json.jbuilder
+++ b/app/views/api/v2/content_records/lesson_plans.json.jbuilder
@@ -15,7 +15,7 @@ json.lesson_plans @lesson_plans do |lesson_plan|
   end
   json.knowledge_areas knowledge_areas
   json.discipline_id discipline_id
-  json.grade_id lesson_plan.grade_id
+  json.grade_id lesson_plan.first_grade.id
   json.unity_id lesson_plan.classroom.unity.id
   json.classroom_id lesson_plan.classroom_id
   json.start_at lesson_plan.start_at

--- a/app/views/api/v2/content_records/sync.json.jbuilder
+++ b/app/views/api/v2/content_records/sync.json.jbuilder
@@ -18,5 +18,5 @@ end
 
 json.knowledge_areas knowledge_areas
 json.discipline_id discipline_id
-json.grade_id @content_record.grade_id
+json.grade_id @content_record.first_grade.id
 json.record_date @content_record.record_date

--- a/app/views/api/v2/teacher_classrooms/index.json.jbuilder
+++ b/app/views/api/v2/teacher_classrooms/index.json.jbuilder
@@ -1,6 +1,6 @@
 json.array!(@classrooms) do |classroom|
   json.id classroom.id
   json.description classroom.description
-  json.grade_id classroom.grade_id
+  json.grade_id classroom.grade_ids.first
   json.year classroom.year
 end

--- a/app/views/avaliation_exemptions/_resources.html.erb
+++ b/app/views/avaliation_exemptions/_resources.html.erb
@@ -7,7 +7,7 @@
     <% @avaliation_exemptions.map { |avaliation_exemption| avaliation_exemption.localized }.each do |avaliation_exemption| %>
       <tr>
         <td><%= avaliation_exemption.avaliation.unity.name %></td>
-        <td><%= avaliation_exemption.avaliation.classroom.grade.description %></td>
+        <td><%= avaliation_exemption.avaliation.grades.map(&:description).join(', ') %></td>
         <td><%= avaliation_exemption.avaliation.classroom.description %></td>
         <td><span class="multiline"><%= avaliation_exemption.student.to_s %></span/></td>
         <td><%= "#{avaliation_exemption.avaliation.description} (#{avaliation_exemption.avaliation.discipline.description})" %></td>

--- a/app/views/avaliations/_avaliation_fields.html.erb
+++ b/app/views/avaliations/_avaliation_fields.html.erb
@@ -3,9 +3,17 @@
     <%= f.input :include, as: :boolean, label: false %>
     <%= f.input :classroom_id, as: :hidden %>
   </td>
+
   <td>
     <%= f.input :classroom, as: :string, label: false, disabled: true %>
   </td>
+
+  <td>
+    <% avaliation_data(f.object) %>
+    <%= f.input :grade_ids, as: :select2, elements: @grades.to_json, label: false, input_html: { value: @input_value },
+                readonly: !@is_multi, multiple: @is_multi %>
+  </td>
+
   <td>
     <%= f.input :test_date, as: :date, input_html: { value: f.object.localized.test_date }, label: false %>
   </td>

--- a/app/views/avaliations/_form.html.erb
+++ b/app/views/avaliations/_form.html.erb
@@ -48,6 +48,14 @@
       <div class="col col-sm-4">
         <%= f.input :weight, required: true, label_html: show_avaliation_weight, input_html: show_avaliation_weight.merge({ data: { inputmask: "'digits': #{@avaliation.test_setting&.number_of_decimal_places || 0}" } }) %>
       </div>
+
+      <div class="col col-sm-4">
+           <%= f.association :grades, as: :select2, elements: grades, multiple: true, required: true,
+               input_html: {
+                 value: f.object.grade_ids.join(',').presence || grades.first.id,
+                 data: { without_json_parser: true }
+            }%>
+      </div>
     </div>
 
     <div class="row">

--- a/app/views/avaliations/_resources.html.erb
+++ b/app/views/avaliations/_resources.html.erb
@@ -7,7 +7,7 @@
     <% @avaliations.each do |avaliation| %>
       <tr>
         <td><%= avaliation.unity %></td>
-        <td><%= avaliation.classroom %></td>
+        <td><%= avaliation.classroom_description %></td>
         <td><%= avaliation.discipline %></td>
         <td><%= l(avaliation.test_date) %></td>
         <td><%= avaliation.current_step %></td>

--- a/app/views/avaliations/multiple_classrooms.html.erb
+++ b/app/views/avaliations/multiple_classrooms.html.erb
@@ -73,8 +73,9 @@
               </div>
             </th>
             <th><%= Avaliation.human_attribute_name(:classroom) %></th>
-            <th width="25%"><%= Avaliation.human_attribute_name(:test_date) %></th>
-            <th width="25%"><%= Avaliation.human_attribute_name(:classes) %></th>
+            <th width="400px"><%= Avaliation.human_attribute_name(:grade) %></th>
+            <th width="300px"><%= Avaliation.human_attribute_name(:test_date) %></th>
+            <th width="300px"><%= Avaliation.human_attribute_name(:classes) %></th>
           </tr>
         </thead>
 

--- a/app/views/classrooms/show.json.jbuilder
+++ b/app/views/classrooms/show.json.jbuilder
@@ -1,4 +1,3 @@
 json.id @classroom.id
 json.description @classroom.description
-json.score_type @classroom.exam_rule.score_type
-
+json.score_type @classroom.first_exam_rule.score_type

--- a/app/views/conceptual_exams/_conceptual_exam_value_fields.html.erb
+++ b/app/views/conceptual_exams/_conceptual_exam_value_fields.html.erb
@@ -18,6 +18,6 @@
     <%= f.input :value, as: :select2,
           elements: f.object.decorator.data_for_select2,
           label_html: { class: 'hidden' },
-          readonly: (f.object.exempted_discipline.to_s == 'true') %>
+          readonly: (f.object.exempted_discipline.to_s == 'true') || action_name == "show" %>
   </td>
 </tr>

--- a/app/views/conceptual_exams/_form.html.erb
+++ b/app/views/conceptual_exams/_form.html.erb
@@ -78,7 +78,7 @@
     <%= link_to t('views.form.back'), conceptual_exams_path, class: 'btn btn-default' %>
     <%= link_to t('views.form.history'), history_conceptual_exam_path(@conceptual_exam),
       class: 'btn btn-info' if @conceptual_exam.persisted? %>
-    <%= f.submit t('views.form.save'), class: 'btn btn-primary', data: { disable_with: 'Salvando...'} %>
-    <%= f.submit t('.save_and_go_to_the_next'), class: 'btn btn-primary', data: { disable_with: 'Salvando...'} %>
+    <%= f.submit t('views.form.save'), id: 'btn-save', class: 'btn btn-primary', data: { disable_with: 'Salvando...'} %>
+    <%= f.submit t('.save_and_go_to_the_next'), id: 'btn-save-and-next', class: 'btn btn-primary', data: { disable_with: 'Salvando...'} %>
   </footer>
 <% end %>

--- a/app/views/conceptual_exams/_resources.html.erb
+++ b/app/views/conceptual_exams/_resources.html.erb
@@ -18,7 +18,7 @@
         </td>
         <td class='actions'>
           <%= link_to t('helpers.links.show_html'), conceptual_exam_path(conceptual_exam), style: "width: 31%;",
-                      class: 'btn btn-primary apply_tooltip apply_tooltip', title: t('conceptual_exams.form.show') %>
+                      class: 'btn btn-info apply_tooltip', title: t('conceptual_exams.form.show') %>
           <% if current_user.can_change?(:conceptual_exams) %>
             <%= link_to t('helpers.links.edit_html'), edit_conceptual_exam_path(conceptual_exam), style: "width: 31%;",
                         class: 'btn btn-success apply_tooltip', title: t('conceptual_exams.form.edit') %>

--- a/app/views/conceptual_exams/_resources.html.erb
+++ b/app/views/conceptual_exams/_resources.html.erb
@@ -17,10 +17,15 @@
           </span>
         </td>
         <td class='actions'>
-          <%= link_to t('views.index.edit'),
-            edit_conceptual_exam_path(conceptual_exam), class: 'btn btn-success' %>
-          <%= link_to t('views.index.delete'), conceptual_exam_path(conceptual_exam),
-            class: 'btn btn-danger', method: 'delete', data: { confirm: t('views.index.confirm') } %>
+          <%= link_to t('helpers.links.show_html'), conceptual_exam_path(conceptual_exam), style: "width: 31%;",
+                      class: 'btn btn-primary apply_tooltip apply_tooltip', title: t('conceptual_exams.form.show') %>
+          <% if current_user.can_change?(:conceptual_exams) %>
+            <%= link_to t('helpers.links.edit_html'), edit_conceptual_exam_path(conceptual_exam), style: "width: 31%;",
+                        class: 'btn btn-success apply_tooltip', title: t('conceptual_exams.form.edit') %>
+            <%= link_to t('helpers.links.destroy_html'), conceptual_exam_path(conceptual_exam), style: "width: 31%;",
+                        class: 'btn btn-danger apply_tooltip', method: 'delete', title: t('conceptual_exams.form.destroy'),
+                        data: { confirm: t('views.index.confirm') } %>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/conceptual_exams/show.html.erb
+++ b/app/views/conceptual_exams/show.html.erb
@@ -1,0 +1,78 @@
+<%= simple_form_for @conceptual_exam, html: { class: 'smart-form' } do |f| %>
+  <%= f.error_notification %>
+
+  <%= render 'base_errors', f: f %>
+
+  <fieldset>
+    <div class="row">
+      <div class="col col-sm-4">
+        <%= f.input :unity_id, as: :select2_unity, user: current_user %>
+      </div>
+
+      <div class="col col-sm-4">
+        <%= f.association :classroom, as: :select2_classroom, user: current_user, record: f.object %>
+      </div>
+
+      <div class="col col-sm-4">
+        <%= f.input :step_id, as: :select2_step, classroom: current_user_classroom,
+                    readonly: @conceptual_exam.persisted?, required: true %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col col-sm-4">
+        <%= f.input :recorded_at, readonly: true %>
+      </div>
+
+      <div class="col col-sm-4">
+        <%= f.association :student, as: :select2, elements: @students,
+                          readonly: @conceptual_exam.persisted? %>
+      </div>
+    </div>
+  </fieldset>
+
+  <fieldset>
+    <table class="table table-bordered table-condensed" id="conceptual_exam_values_table">
+      <thead>
+      <th><%= ConceptualExamValue.human_attribute_name :discipline %></th>
+      <% old_values.each do |step| %>
+        <th class="old_step_column"><%= step[:description] %></th>
+      <% end %>
+      <th width="20%"><%= ConceptualExamValue.human_attribute_name :value %></th>
+      </thead>
+
+      <tbody id="conceptual_exam_values">
+      <tr>
+        <td class="no_item_found" colspan="<%= old_values.count + 2 %>" style="<%= f.object.conceptual_exam_values.reject(&:marked_for_destruction?).reject(&:marked_as_invisible?).empty? ? 'display: table-cell;' : 'display: none;' %>" ><%= t('.no_item_found') %></td>
+      </tr>
+      <% ordered_conceptual_exam_values.each do |knowledge_area, conceptual_exam_values| %>
+        <% if conceptual_exam_values.reject(&:marked_for_destruction?).reject(&:marked_as_invisible?).any? %>
+          <tr class="knowledge-area-table-row">
+            <td class="knowledge-area-table-data" colspan="<%= old_values.count + 2 %>"><strong><%= knowledge_area %></strong></td>
+          </tr>
+        <% end %>
+
+        <%= f.simple_fields_for :conceptual_exam_values, conceptual_exam_values do |conceptual_exam_value_form| %>
+          <%= render 'conceptual_exam_value_fields', f: conceptual_exam_value_form %>
+        <% end %>
+      <% end %>
+
+      <tfoot class='exempted_students_from_discipline_legend <%= 'hidden' unless any_student_exempted_from_discipline? %>'>
+      <tr>
+        <td colspan="<%= old_values.count + 2 %>">
+              <span class="conceptual-exam-student-legend">
+                <%= t('.exempted_students_from_discipline_legend') %>
+              </span>
+        </td>
+      </tr>
+      </tfoot>
+      </tbody>
+      </table>
+  </fieldset>
+
+  <footer>
+    <%= link_to t('views.form.back'), conceptual_exams_path, class: 'btn btn-default' %>
+    <%= link_to t('views.form.history'), history_conceptual_exam_path(@conceptual_exam),
+                class: 'btn btn-info' if @conceptual_exam.persisted? %>
+  </footer>
+<% end %>

--- a/app/views/daily_notes/_student_fields.html.erb
+++ b/app/views/daily_notes/_student_fields.html.erb
@@ -36,7 +36,7 @@
           }
         },
         readonly: student.exempted || !student.active || student.exempted_from_discipline || student.in_active_search,
-        placeholder: ('Dispensado' if student.exempted)
+        placeholder: ('Dispensado' if student.exempted && !student.in_active_search)
       ) %>
       </div>
     </td>

--- a/app/views/daily_notes/exempt_students.js.erb
+++ b/app/views/daily_notes/exempt_students.js.erb
@@ -17,8 +17,6 @@ $.each(students_ids, function(i, student_id){
   }
 
   var noteInput = $("#tr_student_" + student_id + " input[id ^='daily_note_students_attributes'][id $='note']")[0];
-  $(noteInput).attr('readonly', 'readonly');
-  $(noteInput).attr('placeholder', 'Dispensado');
   $(noteInput).val('');
   $(noteInput).addClass('exempted-student');
 
@@ -35,4 +33,9 @@ $.each(students_ids, function(i, student_id){
   undo_exemption_button.attr('data-method', 'post');
   undo_exemption_button.attr('href', undo_url);
   undo_exemption_button.attr('title', 'Desfazer');
+
+  if (!studentName.hasClass('in-active-search')) {
+    $(noteInput).attr('readonly', 'readonly');
+    $(noteInput).attr('placeholder', 'Dispensado');
+  }
 });

--- a/app/views/daily_notes/undo_exemption.js.erb
+++ b/app/views/daily_notes/undo_exemption.js.erb
@@ -4,12 +4,9 @@ if (student_id) {
   $('#exempt_student_check_' + student_id).removeAttr('disabled');
 
   var studentName = $('#student_name_' + student_id);
-  studentName.text(studentName.text().replace('**', ''));
   studentName.removeClass('exempted-student');
 
   var noteInput = $("#tr_student_" + student_id + " input[id ^='daily_note_students_attributes'][id $='note']")[0];
-  $(noteInput).removeAttr('readonly');
-  $(noteInput).removeAttr('placeholder');
   $(noteInput).removeClass('exempted-student');
 
   var undo_exemption_button = $('#do_undo_exemption_' + student_id);
@@ -22,4 +19,10 @@ if (student_id) {
   undo_exemption_button.removeAttr('data-method');
   undo_exemption_button.attr('href', '#');
   undo_exemption_button.attr('title', 'Dispensar');
+
+  if (!studentName.hasClass('in-active-search')) {
+    studentName.text(studentName.text().replace('**', ''));
+    $(noteInput).removeAttr('readonly');
+    $(noteInput).removeAttr('placeholder');
+  }
 }

--- a/app/views/descriptive_exams/edit.html.erb
+++ b/app/views/descriptive_exams/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :js do %>
+  <%= javascript_include_tag 'views/descriptive_exams/functions' %>
   <%= javascript_include_tag 'views/descriptive_exams/student_fields' %>
 <% end %>
 

--- a/app/views/descriptive_exams/new.html.erb
+++ b/app/views/descriptive_exams/new.html.erb
@@ -39,7 +39,11 @@
     </fieldset>
 
     <footer>
-      <%= f.submit 'Carregar', class: 'btn btn-primary', data: { disable_with: 'Carregando...'} %>
+      <% if current_user.can_change?(:descriptive_exams) %>
+        <%= f.submit 'Novo/Editar', class: 'btn btn-success', data: { disable_with: 'Carregando...'} %>
+      <% end %>
+      <%= link_to 'Visualizar', new_descriptive_exam_path, id: 'view-btn', class: 'btn btn-primary disabled',
+                  data: { disable_with: 'Carregando...'} %>
     </footer>
   <% end %>
 </div>

--- a/app/views/descriptive_exams/show.html.erb
+++ b/app/views/descriptive_exams/show.html.erb
@@ -1,0 +1,84 @@
+<% content_for :js do %>
+  <%= javascript_include_tag 'views/descriptive_exams/functions' %>
+  <%= javascript_include_tag 'views/descriptive_exams/show' %>
+<% end %>
+
+<div class="widget-body no-padding">
+  <%= simple_form_for @descriptive_exam, html: { class: "smart-form" } do |f| %>
+    <table class="table table-bordered table-only-inner-bordered">
+      <thead>
+      <th><%= DescriptiveExam.human_attribute_name :unity %></th>
+      <th><%= DescriptiveExam.human_attribute_name :classroom %></th>
+      <% if @descriptive_exam.discipline.present? %>
+        <th><%= DescriptiveExam.human_attribute_name :discipline %></th>
+      <% end %>
+      <% if @descriptive_exam.step_id.present? %>
+        <th><%= DescriptiveExam.human_attribute_name :step %></th>
+      <% end %>
+      </thead>
+
+      <tbody style="border-bottom: 1px solid #ccc;">
+      <td><%= @descriptive_exam.unity %></td>
+      <td><%= @descriptive_exam.classroom %></td>
+      <% if @descriptive_exam.discipline.present? %>
+        <td><%= @descriptive_exam.discipline %></td>
+      <% end %>
+      <% if @descriptive_exam.step_id.present? %>
+        <td><%= @descriptive_exam.step %></td>
+      <% end %>
+      </tbody>
+    </table>
+
+    <%= f.error_notification %>
+
+    <table class="table table-bordered table-only-inner-bordered table-striped table-hover">
+      <colgroup>
+        <col style="width: 65px;" />
+        <col />
+        <col style="width: 50%;" />
+      </colgroup>
+
+      <thead>
+      <th>Sequencial</th>
+      <th><%= DescriptiveExamStudent.human_attribute_name :student %></th>
+      <th><%= DescriptiveExamStudent.human_attribute_name :value %></th>
+      </thead>
+
+      <tbody id="students">
+      <% sequence = 0 %>
+      <%= f.fields_for :students, @normal_students do |student| %>
+        <% sequence += 1 %>
+        <%= render 'student_fields', f: student, sequence: sequence %>
+      <% end %>
+      <% sequence = 0 %>
+      <% if @dependence_students.any? %>
+        <%= f.fields_for :students, @dependence_students do |student| %>
+          <% sequence += 1 %>
+          <%= render 'student_fields', f: student, sequence: sequence %>
+        <% end %>
+        <tr>
+          <td colspan="3">
+              <span class="descriptive-exam-student-legend">
+                <%= t('.dependence_students') %>
+              </span>
+          </td>
+        </tr>
+      <% end %>
+      <% if @any_student_exempted_from_discipline %>
+        <tr>
+          <td colspan="3">
+              <span class="descriptive-exam-student-legend">
+                <%= t('.exempted_students_from_discipline_legend') %>
+              </span>
+          </td>
+        </tr>
+      <% end %>
+      </tbody>
+    </table>
+
+    <footer>
+      <%= link_to t('views.form.history'),
+                  history_descriptive_exam_path(@descriptive_exam), class: 'btn btn-info' %>
+    </footer>
+  <% end %>
+</div>

--- a/app/views/discipline_content_records/_resources.html.erb
+++ b/app/views/discipline_content_records/_resources.html.erb
@@ -19,7 +19,7 @@
                         discipline_content_record_id: discipline_content_record.id,
                         discipline_id: discipline_content_record.discipline_id,
                         classroom_id: discipline_content_record.content_record.classroom.id,
-                        grade_id: discipline_content_record.content_record.classroom.grade_id
+                        grade_id: discipline_content_record.content_record.classroom.grade_ids
                       }) %>
           <%= link_to(
                 t('helpers.links.show_html'),

--- a/app/views/discipline_lesson_plans/_resources.html.erb
+++ b/app/views/discipline_lesson_plans/_resources.html.erb
@@ -36,7 +36,7 @@
                         classroom_id: discipline_lesson_plan.classroom.id,
                         grade_id: (
                           unless GeneralConfiguration.current.allows_copy_lesson_plans_to_other_grades
-                            discipline_lesson_plan.classroom.grade_id
+                            discipline_lesson_plan.classroom.grade_ids
                           end
                         )
                       }) %>

--- a/app/views/discipline_teaching_plans/_form.html.erb
+++ b/app/views/discipline_teaching_plans/_form.html.erb
@@ -41,7 +41,8 @@
         </div>
 
         <div class="col col-sm-4">
-          <%= teaching_plan_form.association :grade, as: :select2_grade, user: current_user %>
+          <%= teaching_plan_form.association :grade, as: :select2_grade, user: current_user,
+                                             readonly: action_name.eql?('show')  %>
         </div>
 
         <div class="col col-sm-4">
@@ -60,7 +61,7 @@
                 ).to_json,
                 input_html: { value: teaching_plan_form.object.school_term_type_id,
                               data: { without_json_parser: true } },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
 
         <div id="school-term-container" class="col col-sm-4">
@@ -69,7 +70,7 @@
         </div>
 
         <div class="col col-sm-4">
-          <%= f.input :thematic_unit, readonly: action_name == 'show' %>
+          <%= f.input :thematic_unit, readonly: action_name.eql?('show') %>
         </div>
       </div>
 
@@ -95,7 +96,7 @@
                         content.id, content.id.in?(@discipline_teaching_plan.contents.collect(&:id)),
                         hidden: true, 'data-content_description': content.to_s ) %>
                     <span style="margin-left: 5px;display: block;width: calc(100% - 85px);"><%= content %></span>
-                    <% if content.is_editable && action_name != 'show' %>
+                    <% if content.is_editable && !action_name.eql?('show') %>
                       <div style="width: 80px;">
                         <a class="btn new-btn-success" onclick="editContent('teaching_plan_<%= content.id %>')">
                           <i class="fa fa-pencil"></i>
@@ -112,7 +113,7 @@
 
         </div>
       </div>
-      <% if action_name != 'show' %>
+      <% if !action_name.eql?('show') %>
         <div class="row textarea">
           <div class="col col-sm-12 contents-select2-container">
             <% translation = Translator.t('activerecord.attributes.discipline_teaching_plan.contents') %>
@@ -139,7 +140,7 @@
               <%= f.object.errors[:'teaching_plan.objectives'].first %>
             </div>
           <% end %>
-          <% if action_name != 'show' %>
+          <% if !action_name.eql?('show') %>
             <a href="#" data-toggle="modal" data-target="#copy-objectives-modal">
               Copiar objetivos/habilidades por área
             </a>
@@ -173,7 +174,7 @@
 
         </div>
       </div>
-      <% if action_name != 'show' %>
+      <% if !action_name.eql?('show') %>
         <div class="row textarea">
           <div class="col col-sm-12 objectives-select2-container">
             <% translation = Translator.t('activerecord.attributes.discipline_teaching_plan.objectives') %>
@@ -196,21 +197,21 @@
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :methodology, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :evaluation, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :references, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
@@ -234,14 +235,14 @@
             <thead>
               <tr>
                 <th><%= t('.attachments') %></th>
-                <% if action_name != 'show' %>
+                <% if !action_name.eql?('show') %>
                   <td width="73px"></td>
                 <% end %>
               </tr>
             </thead>
 
             <tbody id="teaching-plan-attachments">
-              <% if action_name == 'show' && teaching_plan_form.object.teaching_plan_attachments.blank? %>
+              <% if action_name.eql?('show') && teaching_plan_form.object.teaching_plan_attachments.blank? %>
                 <tr class="nested-fields">
                   <td><span>Nenhum documento anexado</span></td>
                 </tr>
@@ -255,7 +256,7 @@
                 <% end %>
               <% end %>
             </tbody>
-            <% if action_name != 'show' %>
+            <% if !action_name.eql?('show') %>
               <tfoot class="links">
                 <tr>
                   <td colspan="2">

--- a/app/views/exam_record_report/form.html.erb
+++ b/app/views/exam_record_report/form.html.erb
@@ -1,3 +1,7 @@
+<% content_for :js do %>
+  <%= javascript_include_tag 'views/exam_record_report/form' %>
+<% end %>
+
 <div class="widget-body no-padding">
   <%= simple_form_for @exam_record_report_form, url: exam_record_report_path, method: :post, html: { class: 'smart-form', target: '_blank' } do |f| %>
     <%= f.error_notification unless @exam_record_report_form.errors[:daily_notes].any? %>

--- a/app/views/infrequency_trackings/_resources.html.erb
+++ b/app/views/infrequency_trackings/_resources.html.erb
@@ -7,7 +7,7 @@
     <% @infrequency_trackings.each do |infrequency_tracking| %>
       <tr>
         <td><%= infrequency_tracking.classroom.unity %></td>
-        <td><%= infrequency_tracking.classroom.grade %></td>
+        <td><%= infrequency_tracking.classroom.grades.map(&:description).join(', ') %></td>
         <td><%= infrequency_tracking.classroom %></td>
         <td><%= infrequency_tracking.student %></td>
         <td><%= l(infrequency_tracking.notification_date) %></td>

--- a/app/views/knowledge_area_content_records/_resources.html.erb
+++ b/app/views/knowledge_area_content_records/_resources.html.erb
@@ -24,7 +24,7 @@
                 data: { original_title: t('views.index.tooltips.copy'),
                         knowledge_area_content_record_id: knowledge_area_content_record.id,
                         classroom_id: knowledge_area_content_record.classroom.id,
-                        grade_id: knowledge_area_content_record.classroom.grade_id
+                        grade_id: knowledge_area_content_record.classroom.grade_ids
                       }) %>
           <%= link_to(
                 t('helpers.links.show_html'),

--- a/app/views/knowledge_area_lesson_plans/_resources.html.erb
+++ b/app/views/knowledge_area_lesson_plans/_resources.html.erb
@@ -41,7 +41,7 @@
                         classroom_id: knowledge_area_lesson_plan.classroom.id,
                         grade_id: (
                           unless GeneralConfiguration.current.allows_copy_lesson_plans_to_other_grades
-                            knowledge_area_lesson_plan.classroom.grade_id
+                            knowledge_area_lesson_plan.classroom.grade_ids
                           end
                         )
                       }) %>

--- a/app/views/knowledge_area_teaching_plans/_form.html.erb
+++ b/app/views/knowledge_area_teaching_plans/_form.html.erb
@@ -37,14 +37,15 @@
         </div>
 
         <div class="col col-sm-4">
-          <%= teaching_plan_form.association :grade, as: :select2_grade, user: current_user %>
+          <%= teaching_plan_form.association :grade, as: :select2_grade, user: current_user,
+                                             readonly: action_name.eql?('show')  %>
         </div>
 
         <div class="col col-sm-4">
           <%= f.input :knowledge_area_ids, as: :select2,
                 elements: @knowledge_areas, multiple: true,
                 input_html: { data: { without_json_parser: true } },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
@@ -58,16 +59,16 @@
                 ).to_json,
                 input_html: { value: teaching_plan_form.object.school_term_type_id,
                               data: { without_json_parser: true } },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
 
         <div id="school-term-container" class="col col-sm-4">
           <%= teaching_plan_form.association :school_term_type_step, as: :select2, elements: [], required: true,
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
 
         <div class="col col-sm-4">
-          <%= f.input :experience_fields, readonly: action_name == 'show' %>
+          <%= f.input :experience_fields, readonly: action_name.eql?('show') %>
         </div>
       </div>
 
@@ -93,7 +94,7 @@
                         content.id, content.id.in?(@knowledge_area_teaching_plan.contents.collect(&:id)),
                         hidden: true, 'data-content_description': content.to_s ) %>
                     <span style="margin-left: 5px;display: block;width: calc(100% - 85px);"><%= content %></span>
-                    <% if content.is_editable && action_name != 'show' %>
+                    <% if content.is_editable && !action_name.eql?('show') %>
                       <div style="width: 80px;">
                         <a class="btn new-btn-success" onclick="editContent('teaching_plan_<%= content.id %>')">
                           <i class="fa fa-pencil"></i>
@@ -110,7 +111,7 @@
 
         </div>
       </div>
-      <% if action_name != 'show' %>
+      <% if !action_name.eql?('show') %>
         <div class="row textarea">
           <div class="col col-sm-12 contents-select2-container">
             <% translation = Translator.t('activerecord.attributes.knowledge_area_teaching_plan.contents') %>
@@ -138,7 +139,7 @@
             </div>
           <% end %>
 
-          <% if action_name != 'show' %>
+          <% if !action_name.eql?('show') %>
             <a href="#" data-toggle="modal" data-target="#copy-objectives-modal">
               Copiar objetivos/habilidades por área
             </a>
@@ -153,7 +154,7 @@
                         objective.id, objective.id.in?(@knowledge_area_teaching_plan.objectives.collect(&:id)),
                         hidden: true, 'data-objective_description': objective.to_s ) %>
                     <span style="margin-left: 5px;display: block;width: calc(100% - 85px);"><%= objective %></span>
-                    <% if objective.is_editable && action_name != 'show' %>
+                    <% if objective.is_editable && !action_name.eql?('show') %>
                       <div style="width: 80px;">
                         <a class="btn new-btn-success"
                           onclick="editObjective('teaching_plan_<%= objective.id %>')">
@@ -172,7 +173,7 @@
 
         </div>
       </div>
-      <% if action_name != 'show' %>
+      <% if !action_name.eql?('show') %>
         <div class="row textarea">
           <div class="col col-sm-12 objectives-select2-container">
             <% translation = Translator.t('activerecord.attributes.knowledge_area_teaching_plan.objectives') %>
@@ -195,21 +196,21 @@
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :methodology, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :evaluation, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
       <div class="row textarea">
         <div class="col col-sm-12">
           <%= teaching_plan_form.input :references, input_html: { class: 'col col-sm-12' },
-                readonly: action_name == 'show' %>
+                readonly: action_name.eql?('show') %>
         </div>
       </div>
 
@@ -233,14 +234,14 @@
             <thead>
               <tr>
                 <th>Anexo</th>
-                <% if action_name != 'show' %>
+                <% if !action_name.eql?('show') %>
                   <td width="73px"></td>
                 <% end %>
               </tr>
             </thead>
 
             <tbody id="teaching-plan-attachments">
-              <% if action_name == 'show' && teaching_plan_form.object.teaching_plan_attachments.blank? %>
+              <% if action_name.eql?('show') && teaching_plan_form.object.teaching_plan_attachments.blank? %>
                 <tr class="nested-fields">
                   <td><span>Nenhum documento anexado</span></td>
                 </tr>
@@ -254,7 +255,7 @@
                 <% end %>
               <% end %>
             </tbody>
-            <% if action_name != 'show' %>
+            <% if !action_name.eql?('show') %>
               <tfoot class="links">
                 <tr>
                   <td colspan="2">
@@ -282,7 +283,7 @@
         </div>
       </fieldset>
 
-      <div style="position: absolute; margin-top: 11px; <%= action_name == 'show' ? 'right: 340px;' : 'right: 340px;' %>">
+      <div style="position: absolute; margin-top: 11px; <%= action_name.eql?('show') ? 'right: 340px;' : 'right: 340px;' %>">
         <%= teaching_plan_form.input :validated, as: :boolean, label: false, inline_label: true, disabled: current_user.teacher? %>
       </div>
     <% end %>
@@ -291,6 +292,6 @@
   <footer>
     <%= link_to t('views.form.back'), knowledge_area_teaching_plans_path, class: 'btn btn-default' %>
     <%= link_to t('views.form.history'), history_knowledge_area_teaching_plan_path(@knowledge_area_teaching_plan), class: 'btn btn-info' if @knowledge_area_teaching_plan.persisted? %>
-    <%= f.submit t('views.form.save'), class: 'btn btn-primary', data: { disable_with: 'Salvando...' } unless action_name == 'show' && current_user.teacher? %>
+    <%= f.submit t('views.form.save'), class: 'btn btn-primary', data: { disable_with: 'Salvando...' } unless action_name.eql?('show') && current_user.teacher? %>
   </footer>
 <% end %>

--- a/app/views/lessons_boards/_form.html.erb
+++ b/app/views/lessons_boards/_form.html.erb
@@ -19,7 +19,7 @@
         <% if action_name == "new" %>
           <%= f.input :grade, as: :select2, elements: [], label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: false, required: true %>
         <% else %>
-          <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classrooms_grade.grade_id }, required: true  %>
+          <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classrooms_grade.grade.description }, required: true  %>
         <% end %>
       </div>
 

--- a/app/views/lessons_boards/_form.html.erb
+++ b/app/views/lessons_boards/_form.html.erb
@@ -13,10 +13,11 @@
       </div>
 
       <div class="col col-sm-3">
+        <%= f.input :classrooms_grade_id, as: :hidden %>
         <% if action_name == "new" %>
           <%= f.input :grade, as: :select2, elements: [], label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: false, required: true %>
         <% else %>
-          <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classroom.grade.description }, required: true  %>
+          <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classrooms_grade.grade_id }, required: true  %>
         <% end %>
       </div>
 

--- a/app/views/lessons_boards/_form.html.erb
+++ b/app/views/lessons_boards/_form.html.erb
@@ -1,3 +1,5 @@
+<%= stylesheet_link_tag "resources/lessons_boards" %>
+
 <%= simple_form_for @lessons_board, html: { class: 'smart-form', id: 'form-submit' } do |f| %>
   <%= f.error_notification %>
   <fieldset>

--- a/app/views/lessons_boards/_resources.html.erb
+++ b/app/views/lessons_boards/_resources.html.erb
@@ -13,7 +13,7 @@
       <td><%= Periods.translate(Periods.key_for(lesson_board.period.to_s)) %></td>
       <td class="actions" style="width: 120px">
         <%= link_to t('helpers.links.show_html'), lessons_board_path(lesson_board),
-                    class: "btn btn-primary apply_tooltip apply_tooltip", style: "width: 32%;",
+                    class: "btn btn-info apply_tooltip apply_tooltip", style: "width: 32%;",
                     data: { original_title: t('views.index.tooltips.show') } %>
         <%= link_to t('helpers.links.edit_html'), edit_lessons_board_path(lesson_board),
                     class: "btn btn-success apply_tooltip", style: "width: 32%;",

--- a/app/views/lessons_boards/_resources.html.erb
+++ b/app/views/lessons_boards/_resources.html.erb
@@ -8,7 +8,7 @@
     <tr>
       <td><%= lesson_board.classroom.year %></td>
       <td><%= lesson_board.classroom.unity.name %></td>
-      <td><%= lesson_board.classroom.grade.description %></td>
+      <td><%= lesson_board.classrooms_grade.grade.description %></td>
       <td><%= lesson_board.classroom.description %></td>
       <td><%= Periods.translate(Periods.key_for(lesson_board.period.to_s)) %></td>
       <td class="actions" style="width: 120px">

--- a/app/views/lessons_boards/show.html.erb
+++ b/app/views/lessons_boards/show.html.erb
@@ -9,7 +9,7 @@
       </div>
 
       <div class="col col-sm-3">
-        <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classroom.grade.description }  %>
+        <%= f.input :grade, label: t('lessons_boards.index.grade'), placeholder: t('lessons_boards.index.grade'), readonly: true, input_html: { value: f.object.classrooms_grade.grade.description }  %>
       </div>
 
       <div class="col col-sm-3">

--- a/app/views/teacher_report_cards/form.html.erb
+++ b/app/views/teacher_report_cards/form.html.erb
@@ -21,6 +21,10 @@
         <div class="col col-sm-4">
           <%= f.input :classroom_id, as: :select2_classroom, user: current_user, input_html: { value: @teacher_report_card_form.classroom_id } %>
         </div>
+        <div class="col col-sm-4">
+           <%= f.input :grade_id, as: :select2_grade, required: true, user: current_user,
+               input_html: { value: f.object.grade_id, data: { without_json_parser: true } }%>
+      </div>
       </div>
       <div class="row">
         <div class="col col-sm-4">

--- a/app/workers/copy_discipline_teaching_plan_worker.rb
+++ b/app/workers/copy_discipline_teaching_plan_worker.rb
@@ -32,7 +32,7 @@ class CopyDisciplineTeachingPlanWorker
 
       unities_ids.each do |unity_id|
         grades_ids.each do |grade_id|
-          classrooms_in_grade = Classroom.where(unity_id: unity_id, grade_id: grade_id).pluck(:id)
+          classrooms_in_grade = Classroom.by_unity(unity_id).by_grade(grade_id).pluck(:id)
           teacher_disciplines_classrooms = TeacherDisciplineClassroom.includes(:teacher).where(
             year: year,
             discipline_id: discipline_id,

--- a/app/workers/ieducar_synchronizer_worker.rb
+++ b/app/workers/ieducar_synchronizer_worker.rb
@@ -54,6 +54,6 @@ class IeducarSynchronizerWorker
   end
 
   def all_entities
-    Entity.to_sync
+    Entity.enable_to_sync
   end
 end

--- a/app/workers/student_dependencies_discarders/base_student_dependencies_discarder_worker.rb
+++ b/app/workers/student_dependencies_discarders/base_student_dependencies_discarder_worker.rb
@@ -29,10 +29,12 @@ class BaseStudentDependenciesDiscarderWorker
           JOIN student_enrollment_classrooms
             ON student_enrollment_classrooms.student_enrollment_id = student_enrollments.id
            AND student_enrollment_classrooms.discarded_at IS NULL
+          JOIN classrooms_grades
+            ON classrooms_grades.id = student_enrollment_classrooms.classrooms_grade_id
          WHERE student_enrollments.student_id = :student_id
            AND student_enrollments.discarded_at IS NULL
            AND student_enrollments.active = 1
-           AND student_enrollment_classrooms.classroom_id = #{classroom_id_column}
+           AND classrooms_grades.classroom_id = #{classroom_id_column}
            AND #{start_date_column} >= CAST(student_enrollment_classrooms.joined_at AS DATE) AND
                (
                  COALESCE(student_enrollment_classrooms.left_at, '') = '' OR

--- a/config/locales/controllers/avaliation.yml
+++ b/config/locales/controllers/avaliation.yml
@@ -3,3 +3,4 @@ pt-BR:
       grades_avoid_destroy: "já foram efetuados lançamentos"
       recovery_avoid_destroy: "existe uma recuperação desta avaliação"
       numeric_exam_absence: 'A disciplina selecionada não possui nota numérica'
+      grades_not_allow_numeric_exam: 'As séries da turma não possuem nota numérica'

--- a/config/locales/forms/teacher_report_card_form.yml
+++ b/config/locales/forms/teacher_report_card_form.yml
@@ -4,5 +4,6 @@ pt-BR:
       teacher_report_card_form:
         unity_id: "Escola"
         classroom_id: "Turma"
+        grade_id: "Série"
         discipline_id: "Disciplina"
         status: "Situação"

--- a/config/locales/models/avaliation.yml
+++ b/config/locales/models/avaliation.yml
@@ -25,6 +25,7 @@ pt-BR:
         test_setting_test: "Tipo de avaliação"
         weight: "Peso"
         observations: "Observações"
+        grades: "Séries"
 
     errors:
       models:
@@ -43,6 +44,9 @@ pt-BR:
                   other: "já existe uma avaliação para uma das aulas informadas"
               weight:
                 cant_be_greater_than: "não pode ser maior que %{value}"
+              grades:
+                should_be_in_test_setting: 'devem estar na configuração de avaliação'
+                discipline_not_in_grades: 'não tem essa disciplina nessas series'
 
   errors:
     avaliations:

--- a/config/locales/models/avaliation.yml
+++ b/config/locales/models/avaliation.yml
@@ -26,6 +26,7 @@ pt-BR:
         weight: "Peso"
         observations: "Observações"
         grades: "Séries"
+        grade: "Série"
 
     errors:
       models:

--- a/config/locales/models/recovery_diary_record.yml
+++ b/config/locales/models/recovery_diary_record.yml
@@ -23,3 +23,4 @@ pt-BR:
               recorded_at_must_be_less_than_or_equal_to_today: "deve ser menor ou igual a data de hoje"
               recorded_at_must_be_in_last_school_calendar_step: "deve ser um dia letivo da última etapa do calendário letivo"
               recovery_date_should_be_greater_or_equal_avaliation_date: "a recuperação deve ocorrer na mesma data ou após a avaliação"
+              uniqueness_of_recorded_at: "já existe uma recuperação de avaliação e/ou etapa para a data informada"

--- a/config/locales/navigation.yml
+++ b/config/locales/navigation.yml
@@ -38,7 +38,7 @@ pt-BR:
     conceptual_exams: "Diário de avaliações conceituais"
     descriptive_exams: "Avaliações descritivas"
     reports: "Relatórios"
-    exam_record_report: "Registro de avaliações"
+    exam_record_report: "Registro de avaliações numéricas"
     attendance_record_report: "Registro de frequência"
     observation_record_report: "Registro de observações"
     discipline_lesson_plan_report: "Registro de conteúdos por disciplina"

--- a/config/locales/routes.yml
+++ b/config/locales/routes.yml
@@ -32,7 +32,7 @@ pt-BR:
     attendance_record: 'registro-de-frequencia'
     observation_record: 'registro-de-observacoes'
     exam_record: 'registro-de-avaliacoes'
-    exam_record_report: 'registro-de-avaliacao'
+    exam_record_report: 'registro-de-avaliacao-numerica'
     knowledge_area_lesson_plan: 'planos-de-aula-por-areas-de-conhecimento'
     knowledge_area_lesson_plans: 'planos-de-aula-por-areas-de-conhecimento'
     knowledge_area_content_record: 'registros-de-conteudos-por-areas-de-conhecimento'

--- a/config/locales/views/conceptual_exams.yml
+++ b/config/locales/views/conceptual_exams.yml
@@ -11,3 +11,6 @@ pt-BR:
       save_and_go_to_the_next: 'Salvar e ir para o próximo'
       no_item_found: 'Nenhuma disciplina'
       exempted_students_from_discipline_legend: '**** Disciplina dispensada para o aluno'
+      show: 'Visualizar'
+      edit: 'Editar'
+      destroy: 'Excluir'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -279,8 +279,9 @@ Rails.application.routes.draw do
       end
     end
     resources :old_steps_conceptual_values, except: [:only]
-    resources :descriptive_exams, only: [:new, :create, :edit, :update], concerns: :history do
+    resources :descriptive_exams, only: [:new, :create, :edit, :show, :update], concerns: :history do
       collection do
+        get :find
         get :opinion_types
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -224,6 +224,9 @@ Rails.application.routes.draw do
       end
     end
     resources :classrooms, only: [:index, :show] do
+      collection do
+        get :multi_grade
+      end
       resources :students, only: [:index]
     end
     resources :contents, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -337,6 +337,7 @@ Rails.application.routes.draw do
         get :not_exists_by_classroom
         get :not_exists_by_classroom_and_period
         get :teacher_in_other_classroom
+        get :classroom_grade
       end
     end
 

--- a/config/synchronization_configs.yml
+++ b/config/synchronization_configs.yml
@@ -55,7 +55,8 @@ synchronizers:
     by_unity: false
     dependents: [
       StudentsSynchronizer,
-      CoursesSynchronizer
+      CoursesSynchronizer,
+      SchoolCalendarDisciplineGradesSynchronizer
     ]
     dependencies: [
       TeachersSynchronizer,
@@ -204,6 +205,13 @@ synchronizers:
     by_unity: true
     dependencies: [
       ClassroomsSynchronizer
+    ]
+  -
+    klass: SchoolCalendarDisciplineGradesSynchronizer
+    by_year: false
+    by_unity: true
+    dependencies: [
+      DisciplinesSynchronizer
     ]
   -
     klass: ActiveSearchesSynchronizer

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -54,7 +54,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/db/migrate/20200517213022_create_labels.rb
+++ b/db/migrate/20200517213022_create_labels.rb
@@ -1,0 +1,13 @@
+class CreateLabels < ActiveRecord::Migration
+  def change
+    create_table :labels do |t|
+      t.string :name
+      t.string :labelable_type
+      t.integer :labelable_id
+
+      t.timestamps null: false
+    end
+
+    add_index :labels, [:labelable_type, :labelable_id]
+  end
+end

--- a/db/migrate/20210412205048_create_school_calendar_discipline_grades.rb
+++ b/db/migrate/20210412205048_create_school_calendar_discipline_grades.rb
@@ -1,0 +1,11 @@
+class CreateSchoolCalendarDisciplineGrades < ActiveRecord::Migration
+  def change
+    create_table :school_calendar_discipline_grades do |t|
+      t.belongs_to :school_calendar
+      t.belongs_to :discipline
+      t.belongs_to :grade
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210412205049_populate_school_calendar_discipline_grades.rb
+++ b/db/migrate/20210412205049_populate_school_calendar_discipline_grades.rb
@@ -1,0 +1,41 @@
+class PopulateSchoolCalendarDisciplineGrades < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      DO $$
+        DECLARE tdc RECORD;
+        DECLARE school_calendar_id INTEGER;
+      BEGIN
+        FOR tdc IN (
+          SELECT DISTINCT
+                 teacher_discipline_classrooms.discipline_id AS discipline_id,
+                 classrooms.grade_id AS grade_id,
+                 classrooms.year AS year,
+                 classrooms.unity_id AS unity_id
+            FROM teacher_discipline_classrooms
+            JOIN classrooms ON teacher_discipline_classrooms.classroom_id = classrooms.id
+        )
+        LOOP
+          SELECT id
+            INTO school_calendar_id
+            FROM school_calendars
+           WHERE year = tdc.year
+             AND unity_id = tdc.unity_id;
+
+          INSERT INTO school_calendar_discipline_grades (
+            school_calendar_id,
+            discipline_id,
+            grade_id,
+            created_at,
+            updated_at
+          ) VALUES (
+            school_calendar_id,
+            tdc.discipline_id,
+            tdc.grade_id,
+            NOW(),
+            NOW()
+          );
+        END LOOP;
+      END$$;
+    SQL
+  end
+end

--- a/db/migrate/20210420175455_create_classrooms_grades.rb
+++ b/db/migrate/20210420175455_create_classrooms_grades.rb
@@ -1,0 +1,10 @@
+class CreateClassroomsGrades < ActiveRecord::Migration
+  def change
+    create_table :classrooms_grades do |t|
+      t.belongs_to :classroom
+      t.belongs_to :grade
+      t.belongs_to :exam_rule
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210420175456_populate_classrooms_grades.rb
+++ b/db/migrate/20210420175456_populate_classrooms_grades.rb
@@ -1,0 +1,31 @@
+class PopulateClassroomsGrades < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      DO $$
+        DECLARE classroom RECORD;
+      BEGIN
+        FOR classroom IN (
+          SELECT classrooms.id AS id,
+                 classrooms.grade_id AS grade_id,
+                 classrooms.exam_rule_id AS exam_rule_id
+            FROM classrooms
+        )
+        LOOP
+          INSERT INTO classrooms_grades (
+            classroom_id,
+            grade_id,
+            exam_rule_id,
+            created_at,
+            updated_at
+          ) VALUES (
+            classroom.id,
+            classroom.grade_id,
+            classroom.exam_rule_id,
+            NOW(),
+            NOW()
+          );
+        END LOOP;
+      END$$;
+    SQL
+  end
+end

--- a/db/migrate/20210420175457_add_classroom_grade_to_student_enrollment_classrooms.rb
+++ b/db/migrate/20210420175457_add_classroom_grade_to_student_enrollment_classrooms.rb
@@ -1,0 +1,5 @@
+class AddClassroomGradeToStudentEnrollmentClassrooms < ActiveRecord::Migration
+  def change
+    add_column :student_enrollment_classrooms, :classrooms_grade_id, :integer
+  end
+end

--- a/db/migrate/20210420175458_update_student_enrollment_classrooms.rb
+++ b/db/migrate/20210420175458_update_student_enrollment_classrooms.rb
@@ -1,0 +1,13 @@
+class UpdateStudentEnrollmentClassrooms < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      UPDATE student_enrollment_classrooms
+         SET classrooms_grade_id = (
+           SELECT classrooms_grades.id
+             FROM classrooms_grades
+            WHERE classrooms_grades.classroom_id = student_enrollment_classrooms.classroom_id
+            LIMIT 1
+         )
+    SQL
+  end
+end

--- a/db/migrate/20210517195700_create_avaliations_grades.rb
+++ b/db/migrate/20210517195700_create_avaliations_grades.rb
@@ -1,0 +1,9 @@
+class CreateAvaliationsGrades < ActiveRecord::Migration
+  def change
+    create_table :avaliations_grades do |t|
+      t.belongs_to :avaliation
+      t.belongs_to :grade
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210517195701_populate_avaliations_grades.rb
+++ b/db/migrate/20210517195701_populate_avaliations_grades.rb
@@ -1,0 +1,34 @@
+class PopulateAvaliationsGrades < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      DO $$
+        DECLARE avaliation RECORD;
+        DECLARE grade_id INTEGER;
+      BEGIN
+        FOR avaliation IN (
+          SELECT avaliations.id AS id,
+                 avaliations.classroom_id AS classroom_id
+            FROM avaliations
+        )
+        LOOP
+          SELECT classrooms.grade_id
+            INTO grade_id
+            FROM classrooms
+           WHERE id = avaliation.classroom_id;
+
+          INSERT INTO avaliations_grades (
+            avaliation_id,
+            grade_id,
+            created_at,
+            updated_at
+          ) VALUES (
+            avaliation.id,
+            grade_id,
+            NOW(),
+            NOW()
+          );
+        END LOOP;
+      END$$;
+    SQL
+  end
+end

--- a/db/migrate/20210517195713_update_classroom_to_daily_note_statuses_view.rb
+++ b/db/migrate/20210517195713_update_classroom_to_daily_note_statuses_view.rb
@@ -1,0 +1,56 @@
+class UpdateClassroomToDailyNoteStatusesView < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+    DROP VIEW daily_note_statuses;
+
+      CREATE VIEW daily_note_statuses AS
+        SELECT outer_daily_notes.id AS daily_note_id,
+          CASE
+            WHEN (
+              EXISTS (
+                SELECT daily_notes.id
+                  FROM daily_notes
+                  JOIN daily_note_students ON (
+                    daily_notes.id = daily_note_students.daily_note_id
+                  )
+                  JOIN avaliations ON (
+                    daily_notes.avaliation_id = avaliations.id
+                  )
+                 WHERE daily_note_students.note IS NULL
+                   AND daily_note_students.active = true
+                   AND NOT (
+                     EXISTS (
+                       SELECT 1
+                         FROM avaliation_exemptions
+                        WHERE avaliation_exemptions.avaliation_id = daily_notes.avaliation_id
+                          AND avaliation_exemptions.student_id = daily_note_students.student_id
+                     )
+                   )
+                   AND (
+                     EXISTS (
+                       SELECT 1
+                         FROM student_enrollment_classrooms
+                         JOIN classrooms_grades ON (
+                          student_enrollment_classrooms.classrooms_grade_id = classrooms_grades.id
+                         )
+                         AND classrooms_grades.classroom_id = avaliations.classroom_id
+                         JOIN student_enrollments ON (
+                           student_enrollment_classrooms.student_enrollment_id = student_enrollments.id
+                         )
+                          AND student_enrollments.student_id = daily_note_students.student_id
+                          AND student_enrollment_classrooms.left_at = ''
+                          AND student_enrollments.active = 1
+                     )
+                   )
+                 AND daily_notes.id = outer_daily_notes.id
+              )
+            )
+            THEN
+              'incomplete'::text
+            ELSE
+              'complete'::text
+          END AS status
+        FROM daily_notes outer_daily_notes;
+    SQL
+  end
+end

--- a/db/migrate/20210517195714_update_materialized_view_mvw_infrequency_tracking_classrooms.rb
+++ b/db/migrate/20210517195714_update_materialized_view_mvw_infrequency_tracking_classrooms.rb
@@ -1,0 +1,20 @@
+class UpdateMaterializedViewMvwInfrequencyTrackingClassrooms < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      DROP MATERIALIZED VIEW mvw_infrequency_tracking_classrooms;
+
+      CREATE MATERIALIZED VIEW mvw_infrequency_tracking_classrooms AS
+      SELECT classrooms.id AS id,
+             classrooms.description AS description,
+             classrooms.year AS year,
+             classrooms_grades.grade_id AS grade_id,
+             classrooms.unity_id AS unity_id
+        FROM infrequency_trackings
+        JOIN classrooms
+          ON classrooms.id = infrequency_trackings.classroom_id
+        JOIN classrooms_grades
+          ON classrooms_grades.classroom_id = classrooms.id
+    GROUP BY classrooms.id, classrooms.description, classrooms.year, classrooms_grades.grade_id, classrooms.unity_id;
+    SQL
+  end
+end

--- a/db/migrate/20210517195715_remove_grade_id_from_classrooms.rb
+++ b/db/migrate/20210517195715_remove_grade_id_from_classrooms.rb
@@ -1,0 +1,5 @@
+class RemoveGradeIdFromClassrooms < ActiveRecord::Migration
+  def change
+    remove_column :classrooms, :grade_id
+  end
+end

--- a/db/migrate/20210517195716_remove_exam_rule_id_from_classrooms.rb
+++ b/db/migrate/20210517195716_remove_exam_rule_id_from_classrooms.rb
@@ -1,0 +1,5 @@
+class RemoveExamRuleIdFromClassrooms < ActiveRecord::Migration
+  def change
+    remove_column :classrooms, :exam_rule_id
+  end
+end

--- a/db/migrate/20210517195737_remove_classroom_id_from_student_enrollment_classrooms.rb
+++ b/db/migrate/20210517195737_remove_classroom_id_from_student_enrollment_classrooms.rb
@@ -1,0 +1,5 @@
+class RemoveClassroomIdFromStudentEnrollmentClassrooms < ActiveRecord::Migration
+  def change
+    remove_column :student_enrollment_classrooms, :classroom_id
+  end
+end

--- a/db/migrate/20220117194929_add_classrooms_grade_id_to_lessons_board.rb
+++ b/db/migrate/20220117194929_add_classrooms_grade_id_to_lessons_board.rb
@@ -1,0 +1,5 @@
+class AddClassroomsGradeIdToLessonsBoard < ActiveRecord::Migration
+  def change
+    add_column :lessons_boards, :classrooms_grade_id, :integer
+  end
+end

--- a/db/migrate/20220117194930_update_lessons_board.rb
+++ b/db/migrate/20220117194930_update_lessons_board.rb
@@ -1,0 +1,13 @@
+class UpdateLessonsBoard < ActiveRecord::Migration
+  def change
+    execute <<-SQL
+      UPDATE lessons_boards
+         SET classrooms_grade_id = (
+           SELECT classrooms_grades.id
+             FROM classrooms_grades
+            WHERE classrooms_grades.classroom_id = lessons_boards.classroom_id
+            LIMIT 1
+         )
+    SQL
+  end
+end

--- a/db/migrate/20220117195519_remove_classroom_id_from_lessons_board.rb
+++ b/db/migrate/20220117195519_remove_classroom_id_from_lessons_board.rb
@@ -1,0 +1,5 @@
+class RemoveClassroomIdFromLessonsBoard < ActiveRecord::Migration
+  def change
+    remove_column :lessons_boards, :classroom_id
+  end
+end

--- a/db/migrate/20220209133459_add_label_color_to_discipline.rb
+++ b/db/migrate/20220209133459_add_label_color_to_discipline.rb
@@ -1,0 +1,5 @@
+class AddLabelColorToDiscipline < ActiveRecord::Migration
+  def change
+    add_column :disciplines, :label_color, :string
+  end
+end

--- a/db/migrate/20220209202240_populate_label_color_to_discipline.rb
+++ b/db/migrate/20220209202240_populate_label_color_to_discipline.rb
@@ -1,0 +1,21 @@
+class PopulateLabelColorToDiscipline < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.connection.execute(
+      <<-SQL
+        CREATE OR REPLACE FUNCTION random_color_pick()
+          RETURNS text AS
+        $func$
+        DECLARE
+          a text[] := '{#1C1C1C,#363636,#4F4F4F,#696969,#808080,#A9A9A9,#6A5ACD,#836FFF,#6959CD,#483D8B,#191970,#000080,#0000CD,#6495ED,#4169E1,#1E90FF,#00BFFF,#87CEFA,#87CEEB,#4682B4,#00CED1,#40E0D0,#48D1CC,#20B2AA,#008B8B,#66CDAA,#5F9EA0,#8FBC8F,#3CB371,#2E8B57,#006400,#008000,#32CD32,#9ACD32,#6B8E23,#556B2F,#808000,#BDB76B,#DAA520,#B8860B,#8B4513,#A0522D,#BC8F8F,#CD853F,#D2691E,#F4A460,#DEB887,#7B68EE,#9370DB,#8A2BE2,#4B0082,#9400D3,#BA55D3,#8B008B,#EE82EE,#DA70D6,#DDA0DD,#C71585,#FF69B4,#DB7093,#FFB6C1,#F08080,#CD5C5C,#DC143C,#800000,#B22222,#FA8072,#E9967A,#FF7F50,#FF6347,#FF4500,#FFA500,#FFD700,1}';
+        BEGIN
+          RETURN a[floor((random() * array_length(a, 1)))::int];
+        END
+        $func$ LANGUAGE plpgsql VOLATILE;
+
+        update disciplines set label_color = random_color_pick();
+
+        DROP FUNCTION random_color_pick();
+      SQL
+    )
+  end
+end

--- a/db/migrate/20220216121312_add_api_code_and_discarded_at_to_active_search.rb
+++ b/db/migrate/20220216121312_add_api_code_and_discarded_at_to_active_search.rb
@@ -1,0 +1,6 @@
+class AddApiCodeAndDiscardedAtToActiveSearch < ActiveRecord::Migration
+  def change
+    add_column :active_searches, :api_code, :string
+    add_column :active_searches, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20220222152831_add_discarded_at_to_classrooms_grade.rb
+++ b/db/migrate/20220222152831_add_discarded_at_to_classrooms_grade.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtToClassroomsGrade < ActiveRecord::Migration
+  def change
+    add_column :classrooms_grades, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20220321200424_remove_index_teacher_discipline_classroom.rb
+++ b/db/migrate/20220321200424_remove_index_teacher_discipline_classroom.rb
@@ -1,0 +1,16 @@
+class RemoveIndexTeacherDisciplineClassroom < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    execute %(
+      DROP INDEX CONCURRENTLY IF EXISTS idx_unique_not_discarded_teacher_discipline_classrooms
+    )
+  end
+
+  def down
+    add_index  :teacher_discipline_classrooms, [:api_code, :teacher_id, :classroom_id, :discipline_id],
+               name: 'idx_unique_not_discarded_teacher_discipline_classrooms', unique: true,
+               algorithm: :concurrently, where: 'discarded_at IS NULL'
+  end
+end
+

--- a/db/migrate/20220321201011_add_index.rb
+++ b/db/migrate/20220321201011_add_index.rb
@@ -1,0 +1,9 @@
+class AddIndex < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :teacher_discipline_classrooms, [:api_code, :teacher_id, :classroom_id, :discipline_id, :year],
+              name: 'idx_unique_not_discarded_teacher_discipline_classrooms', unique: true,
+              algorithm: :concurrently, where: 'discarded_at IS NULL'
+  end
+end

--- a/vendor/assets/javascripts/jquery-ui.js
+++ b/vendor/assets/javascripts/jquery-ui.js
@@ -8432,7 +8432,7 @@ $.extend(Datepicker.prototype, {
 
 		prev = (this._canAdjustMonth(inst, -1, drawYear, drawMonth) ?
 			"<a class='ui-datepicker-prev ui-corner-all' data-handler='prev' data-event='click'" +
-			" title='" + prevText + "'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "e" : "w") + "'>" + prevText + "</span></a>" :
+			" title='Anterior'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "e" : "w") + "'>" + prevText + "</span></a>" :
 			(hideIfNoPrevNext ? "" : "<a class='ui-datepicker-prev ui-corner-all ui-state-disabled' title='"+ prevText +"'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "e" : "w") + "'>" + prevText + "</span></a>"));
 
 		nextText = this._get(inst, "nextText");
@@ -8442,7 +8442,7 @@ $.extend(Datepicker.prototype, {
 
 		next = (this._canAdjustMonth(inst, +1, drawYear, drawMonth) ?
 			"<a class='ui-datepicker-next ui-corner-all' data-handler='next' data-event='click'" +
-			" title='" + nextText + "'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "w" : "e") + "'>" + nextText + "</span></a>" :
+			" title='Próximo'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "w" : "e") + "'>" + nextText + "</span></a>" :
 			(hideIfNoPrevNext ? "" : "<a class='ui-datepicker-next ui-corner-all ui-state-disabled' title='"+ nextText + "'><span class='ui-icon ui-icon-circle-triangle-" + ( isRTL ? "w" : "e") + "'>" + nextText + "</span></a>"));
 
 		currentText = this._get(inst, "currentText");

--- a/vendor/assets/stylesheets/smart_admin/smartadmin-production.css.erb
+++ b/vendor/assets/stylesheets/smart_admin/smartadmin-production.css.erb
@@ -22930,9 +22930,6 @@ label:hover input[type="checkbox"][disabled].checkbox:checked + span:before {
   #logo {
     width: 135px;
   }
-  #logo-group {
-    width: 169px !important;
-  }
   /* spark line top */
   #sparks {
     text-align: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4492,9 +4492,9 @@ minimatch@^3.0.4, minimatch@~3.0.2:
     brace-expansion "^1.1.7"
 
 minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7265,9 +7265,9 @@ urix@^0.1.0:
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
 url-parse@^1.4.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.3.tgz#71c1303d38fb6639ade183c2992c8cc0686df862"
-  integrity sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==
+  version "1.5.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.7.tgz#00780f60dbdae90181f51ed85fb24109422c932a"
+  integrity sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,9 +3085,9 @@ flush-write-stream@^1.0.0:
     readable-stream "^2.3.6"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
-  integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
+  version "1.14.8"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
+  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**Novidades**
- Permite o cadastro de turmas multisseriadas.

**Melhorias**
- Valida se data da criação de eventos esta entre a etapa do calendário letivo.
- Cria opção de visualizar na tela de avaliações conceituais.
- Cria opção de visualizar na tela de avaliações descritivas.
- Não permite acessar a tela de justificativa de faltas sem turma selecionada.
- Melhora apresentação das disciplinas no Quadro de aulas.
- Permite criar avaliações numéricas para múltiplas turmas multisseriadas.
- Mostra mensagem de erro ao tentar lançar avaliação conceitual para etapa que já tenha uma avaliação lançada.
- Altera titulo de ícone do componente de seleção de datas.

**Fixes**
- Corrige erro de css na alteração do perfil.
- Corrige problema de sequência na enturmação.
- Corrige estrutura de soft delete de quadro de aulas.
- Considera apenas entidades ativas e com sincronização habilitada para sincronizar.
- Refatora como é feito a busca de alunos em notas de transferência.
- Adiciona model de label e migration.
- Corrige mensagem de erro em recuperações finais.
- Várias correções relacionadas as mudanças de multisseriadas.