### PR TITLE
Criando avalição numérica quando a regra de avaliação for numérica e conceitual

### DIFF
--- a/app/controllers/avaliations_controller.rb
+++ b/app/controllers/avaliations_controller.rb
@@ -218,6 +218,7 @@ class AvaliationsController < ApplicationController
       :classroom_id,
       :discipline_id,
       :test_date,
+      :classes,
       :description,
       :test_setting_test_id,
       :weight,
@@ -305,14 +306,18 @@ class AvaliationsController < ApplicationController
 
   def not_allow_numerical_exam
     grades_by_numerical_exam = current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC).map(&:grade)
+    grades_by_numerical_and_concept_exam = current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC_AND_CONCEPT).map(&:grade)
 
-    return if grades_by_numerical_exam.present?
+    return if grades_by_numerical_exam.present? || grades_by_numerical_and_concept_exam.present?
 
     redirect_to avaliations_path, alert: t('avaliation.grades_not_allow_numeric_exam')
   end
 
   def grades
-    @grades ||= current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC).map(&:grade)
+    numeric_grades = current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC)
+    numeric_and_concept_grades = current_user_classroom.classrooms_grades.by_score_type(ScoreTypes::NUMERIC_AND_CONCEPT)
+    
+    @grades ||= (numeric_grades + numeric_and_concept_grades).map(&:grade)
   end
   helper_method :grades
 end


### PR DESCRIPTION
Criando avalição numérica quando a regra de avaliação for numérica e conceitual

## Descrição
- Adicionando a recuperação de grades para regras de avaliação configuradas como NUMERIC_AND_CONCEPT

## Contexto e motivação
- Não estava permitindo criar uma avaliação numérica quando a regra de avaliação da série estava configurada como **NUMERIC_AND_CONCEPT**

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**
- ✅ Criei testes que cobrem minhas alterações.
