### PR TITLE
Ajusta para pegar os ids de série corretamente

### DIFF
--- a/app/services/teacher_relation_fetcher.rb
+++ b/app/services/teacher_relation_fetcher.rb
@@ -26,7 +26,9 @@ class TeacherRelationFetcher
   end
 
   def exists_all_grades_in_relation?
-    found_grade_ids = teacher_discipline_classrooms.by_grade_id(@grade_ids).pluck(:grade_id)
+    classroom_ids = teacher_discipline_classrooms.by_grade_id(@grade_ids).pluck(:classroom_id)
+    found_grade_ids = ClassroomsGrade.where(classroom_id: classroom_ids, grade_id: @grade_ids)
+                                     .pluck(:grade_id).uniq
 
     (@grade_ids & found_grade_ids) == @grade_ids
   end


### PR DESCRIPTION
**Descrição da mudança:**

Por algum motivo, a tabela `teacher_discipline_classrooms` está sem os `grade_ids`, acredito que pode ser impacto da alteração das turmas multisseriadas.

Com isso, esta lógica que foi ajustada se fazia obsoleta. 

Alteramos para, sempre pegar os `grade_ids` na tabela `ClassroomsGrade`, baseado no id da série(`grade_id`) e no id da turma(`classroom_id`) onde o professor tem alocação. Desta forma, a lógica deve funcionar sem maiores problemas.

**Impactos da mudança:**
Serão impactadas apenas as classes que dão `include` de `TeacherRelationable` e que, setam o atributo `grades` como uma coluna que deve ser validada.

Olhando todas as classes do projeto, a única que inclui a validação de série(`grades`) é a: `i-diario/app/models/teaching_plan.rb`, conforme print abaixo

![image](https://github.com/loginx-tech/i-diario/assets/52477784/658fa959-6648-4c51-bc81-9e88b410f51f)
