### PR TITLE
Desabilita carrierwave do ambiente de desenvolvimento

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,7 +1,7 @@
 FOG_AUTHENTICATED_URL_EXPIRATION = 14_400 # 4 hours
 
 CarrierWave.configure do |config|
-  if Rails.application.secrets['AWS_ACCESS_KEY_ID']
+  if Rails.application.secrets['AWS_ACCESS_KEY_ID'] && !Rails.env.development?
     config.storage = :aws
     config.aws_bucket = Rails.application.secrets[:AWS_BUCKET]
     config.aws_acl = 'private'


### PR DESCRIPTION
Esta PR, agora, desabilita o carrierwave do ambiente de desenvolvimento 

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Contexto e motivação

Essa alteração foi necessária pois ao realizar uma alteração na tela de Administrativo > Configurações Gerais a tela ficava em branco, devido ao sistema que tentava buscar um arquivo de backup que estava salvo no AWS desnecessariamente (visto que é ambiente de desenvolvimento), pois neste cenário existe um backup upado na AWS. A motivação por trás dessas alteração é resolver esse problema e garantir que futuras modificações não causem mais esse comportamento indesejado.

## Resultados

Está é a tela antes da alteração quando o desenvolvedor tenta realizar uma alteração:

![antes_alteração](https://github.com/portabilis/i-diario/assets/146759263/68270fa1-fe2f-4c07-9b02-cb8eb8ad0134)

Após a alteração do código, com a correção do bug

![após_alteração](https://github.com/portabilis/i-diario/assets/146759263/f42a0039-f25a-4b38-a682-e9b90fc99f7c)

