### PR TITLE
Evitando Classrom e SchoolCalendar já está em uso

### DIFF
--- a/app/services/ieducar_synchronizers/school_calendar_classrooms_synchronizer.rb
+++ b/app/services/ieducar_synchronizers/school_calendar_classrooms_synchronizer.rb
@@ -43,11 +43,11 @@ class SchoolCalendarClassroomsSynchronizer < BaseSynchronizer
 
         begin
           SchoolCalendarClassroom.find_or_initialize_by(
-            classroom_id: classroom_id
+            classroom_id: classroom_id,
+            school_calendar_id: school_calendar.id
           ).tap do |school_calendar_classroom|
             school_calendar_classroom.step_type_description = school_calendar_classroom_record.descricao
-            school_calendar_classroom.school_calendar_id = school_calendar.id
-
+            
             school_calendar_classroom.save! if school_calendar_classroom.changed?
 
             @school_calendar_classroom_steps_ids = []


### PR DESCRIPTION
## Descrição
Ao fazer a sincronização estava aparecendo as seguintes mensagens `Classroom já está em uso` e `SchoolCalendar já está em uso`.

![Captura de tela de 2024-06-25 05-52-39](https://github.com/portabilis/i-diario/assets/5889193/4f8b8216-a7cf-426a-bb1a-9df134678bcf)

## Contexto e motivação
Não estava finalizando a sincronização. Completava os 100% em seguida aparecia a mensagem de erro acima.

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**