### PR TITLE
Corrigindo chamada de método `Classroom.by_unity_id`

### DIFF
--- a/app/controllers/absence_justification_report_controller.rb
+++ b/app/controllers/absence_justification_report_controller.rb
@@ -81,7 +81,7 @@ class AbsenceJustificationReportController < ApplicationController
 
     return fetch_linked_by_teacher unless current_user.current_role_is_admin_or_employee?
 
-    @classrooms ||= Classroom.by_unity_id(@absence_justification_report_form.unity_id)
+    @classrooms ||= Classroom.by_unity(@absence_justification_report_form.unity_id)
                              .by_year(current_user_school_year || Date.current.year)
                              .ordered
   end

--- a/app/controllers/avaliations_controller.rb
+++ b/app/controllers/avaliations_controller.rb
@@ -324,7 +324,7 @@ class AvaliationsController < ApplicationController
   def classrooms_for_multiple_classrooms
     return [] if @avaliation_multiple_creator_form.discipline_id.blank?
 
-    @classrooms_for_multiple_classrooms ||= Classroom.by_unity_id(current_unity.id)
+    @classrooms_for_multiple_classrooms ||= Classroom.by_unity(current_unity.id)
                                                      .by_teacher_id(current_teacher.id)
                                                      .by_teacher_discipline(
                                                        @avaliation_multiple_creator_form.discipline_id

--- a/app/controllers/knowledge_area_lesson_plan_report_controller.rb
+++ b/app/controllers/knowledge_area_lesson_plan_report_controller.rb
@@ -81,7 +81,7 @@ class KnowledgeAreaLessonPlanReportController < ApplicationController
   def fetch_collections
     @number_of_classes = current_school_calendar.number_of_classes
     @knowledge_areas = KnowledgeArea.all
-    @classrooms = Classroom.by_unity_id(@knowledge_area_lesson_plan_report_form.unity_id)
+    @classrooms = Classroom.by_unity(@knowledge_area_lesson_plan_report_form.unity_id)
                            .by_year(current_user_school_year || Date.current.year)
                            .ordered
   end

--- a/app/controllers/teacher_report_cards_controller.rb
+++ b/app/controllers/teacher_report_cards_controller.rb
@@ -134,7 +134,7 @@ class TeacherReportCardsController < ApplicationController
   end
 
   def fetch_options_by_admin
-    @classrooms ||= Classroom.by_unity_id(@teacher_report_card_form.unity_id)
+    @classrooms ||= Classroom.by_unity(@teacher_report_card_form.unity_id)
                              .by_grade(@teacher_report_card_form.grade_id)
                              .by_year(current_user_school_year || Date.current.year)
                              .ordered


### PR DESCRIPTION
## Descrição
Estava chamando um método que não existe na classe `Classroom`

## Contexto e motivação
Relatórios não estavam abrindo

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**