### PR TITLE
Erro quando professor acessa

### DIFF
--- a/app/controllers/discipline_content_records_controller.rb
+++ b/app/controllers/discipline_content_records_controller.rb
@@ -46,7 +46,7 @@ class DisciplineContentRecordsController < ApplicationController
 
     unless current_user.current_role_is_admin_or_employee?
       classroom_id = @discipline_content_record.content_record.classroom_id
-      @disciplines = @disciplines.by_classroom_id(classroom_id).not_descriptor
+      @disciplines = Discipline.by_classroom_id(classroom_id).not_descriptor
     end
 
     authorize @discipline_content_record


### PR DESCRIPTION
Fixando erro ao abrir tela de cadastro de registro de conteúdo por disciplina

## Descrição
Ocorria um erro genérico e redirecionava para tela inicial.
`ERROR -- : app/controllers/discipline_content_records_controller.rb:49:in `new'`

## Contexto e motivação
Não conseguia registrar conteúdo por disciplina.

## Tipos de alterações
- ✅ Correção de bugs (Não quebra outras funcionalidades)

## Checklist:
- ✅ Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- ✅ Meu código segue o style guide. **[REQUIRED]**
- ✅ Todos os testes novos e existentes estão passando. **[REQUIRED]**