### PR TITLE
fix: corrige fallback da configuração de região AWS

### DIFF
--- a/app/uploaders/doc_uploader.rb
+++ b/app/uploaders/doc_uploader.rb
@@ -19,7 +19,7 @@ class DocUploader < CarrierWave::Uploader::Base
     {
       access_key_id:     Rails.application.secrets['AWS_ACCESS_KEY_ID'],
       secret_access_key: Rails.application.secrets['AWS_SECRET_ACCESS_KEY'],
-      region:            Rails.application.secrets['DOC_UPLOADER_AWS_REGION'],
+      region:            Rails.application.secrets['DOC_UPLOADER_AWS_REGION'] || Rails.application.secrets['AWS_REGION'],
       stub_responses:    Rails.env.test?
     }
   end


### PR DESCRIPTION
# Descrição

- Corrigido o `or` lógico para utilizar `AWS_REGION` como fallback correto de `DOC_UPLOADER_AWS_REGION`.
