### PR TITLE
Melhora documentação referente ao monitoramento com Honeybadger

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ ajudar a alcançar nossos objetivos.
 
 Consulte o passo a passo no [guia de instalação](INSTALL.md).
 
+## Documentação técnica
+
+Consulte a [documentação técnica](docs/README.md).
+
 ## Perguntas frequentes (FAQ)
 
 Algumas perguntas aparecem recorrentemente. Olhe primeiro por aqui: [FAQ](https://github.com/portabilis/i-educar-website/blob/master/docs/faq.md).

--- a/config/honeybadger.sample.yml
+++ b/config/honeybadger.sample.yml
@@ -1,0 +1,5 @@
+---
+production:
+  api_key: 'SUA_API_KEY_AQUI'
+  breadcrumbs:
+    enabled: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,9 @@ Detalha o processo de sincronização com o i-Educar:
 - Configuração e monitoramento
 - Tratamento de erros
 
+### [Sistema de Monitoramento](./sistema-de-monitoramento-honeybadger.md)
+Detalha o processo de ativação do monitoramento para o i-Diário:
+
 ## Como Contribuir
 
 Para adicionar nova documentação:

--- a/docs/sistema-de-monitoramento-honeybadger.md
+++ b/docs/sistema-de-monitoramento-honeybadger.md
@@ -1,0 +1,51 @@
+# Monitoramento com Honeybadger
+
+Este projeto possui suporte integrado ao [Honeybadger](https://www.honeybadger.io), uma ferramenta de monitoramento de erros para aplicações Ruby on Rails.
+
+## Visão geral
+
+O Honeybadger permite que erros e exceções em produção sejam monitorados automaticamente, com notificações detalhadas e breadcrumbs de contexto. A integração já está preparada no código-fonte — basta ativar a configuração com a sua API Key.
+
+## Como ativar o monitoramento
+
+1. Acesse [https://app.honeybadger.io](https://app.honeybadger.io)
+2. Crie uma conta ou entre com sua conta existente.
+3. Crie um novo projeto (Project).
+4. No painel do projeto, copie a **API Key** disponível.
+5. Copie o arquivo de configuração de exemplo:
+
+   ```bash
+   cp config/honeybadger.sample.yml config/honeybadger.yml
+   ```
+
+6. Edite o arquivo `config/honeybadger.yml` e substitua o valor da chave `api_key` pela sua API Key:
+
+   ```yaml
+   # config/honeybadger.yml
+   ---
+   production:
+     api_key: 'SUA_API_KEY_AQUI'
+     breadcrumbs:
+       enabled: true
+   ```
+
+> A configuração será carregada automaticamente quando o ambiente estiver definido como `RAILS_ENV=production`.
+
+## Exemplo de log no console
+
+Quando corretamente configurado, os erros serão reportados automaticamente ao painel do Honeybadger. Você também poderá ver logs como:
+
+```bash
+[Honeybadger] Reporting error id=abc123 level=1 pid=12345
+```
+
+## Arquivo incluído
+
+Este repositório inclui:
+
+- `config/honeybadger.sample.yml`: Arquivo de exemplo para facilitar a ativação.
+
+## Saiba mais
+
+- Documentação oficial: [https://docs.honeybadger.io](https://docs.honeybadger.io)
+- Configurações avançadas: [https://docs.honeybadger.io/lib/ruby/reference/configuration.html](https://docs.honeybadger.io/lib/ruby/reference/configuration.html)


### PR DESCRIPTION
## O que foi feito

- Adicionado arquivo `config/honeybadger.sample.yml` com a estrutura base para ativação do Honeybadger em produção.
- Criado arquivo `docs/habilitar-honeybadger.md` com instruções detalhadas sobre como configurar o monitoramento de erros com [Honeybadger](https://www.honeybadger.io).
- Atualizado `README.md` com referência à documentação de ativação.

## Motivação

O projeto já possui suporte ao Honeybadger via Gem, mas faltava uma documentação clara e um arquivo de exemplo para facilitar a configuração por novos usuários ou integradores.

## Como testar

1. Renomeie o arquivo `config/honeybadger.sample.yml` para `honeybadger.yml`.
2. Insira uma API Key válida.
3. Certifique-se de que o ambiente esteja rodando em `production` e que uma exceção ocorra para validar o envio para o Honeybadger.