### PR TITLE
fix: Sidekiq workers serialization by passing IDs instead of AR objects

### DIFF
--- a/app/services/ieducar_synchronizers/synchronization_orchestrator.rb
+++ b/app/services/ieducar_synchronizers/synchronization_orchestrator.rb
@@ -76,7 +76,7 @@ class SynchronizationOrchestrator
       params.slice(
         :entity_id,
         :current_years,
-        :synchronization
+        :synchronization_id
       ).merge(
         klass: synchronizer[:klass],
         worker_batch_id: worker_batch.id,

--- a/app/services/ieducar_synchronizers/synchronizer_builder.rb
+++ b/app/services/ieducar_synchronizers/synchronizer_builder.rb
@@ -3,7 +3,11 @@ class SynchronizerBuilder
     params = params.with_indifferent_access
 
     synchronization = params[:synchronization]
+    synchronization ||= IeducarApiSynchronization.find(params[:synchronization_id])
+
     params[:synchronization_id] = synchronization.id
+    params.delete(:synchronization)
+
     years = params[:years] if params[:filtered_by_year]
     years ||= [params[:years].join(',')]
     by_unity = params[:filtered_by_unity] &&

--- a/app/workers/ieducar/synchronizer_builder_enqueue_worker.rb
+++ b/app/workers/ieducar/synchronizer_builder_enqueue_worker.rb
@@ -61,7 +61,7 @@ class SynchronizerBuilderEnqueueWorker
       :unity_api_code,
       :current_years
     ).merge(
-      synchronization: synchronization
+      synchronization_id: synchronization.id
     )
   end
 end


### PR DESCRIPTION
Descrição                                                                                                                                            
  Alteração dos workers e serviços de sincronização do i-Educar para trafegarem apenas o synchronization_id e o entity_id via Sidekiq. Anteriormente,  
  o código tentava passar o objeto ActiveRecord completo, o que causava falhas de serialização JSON no Sidekiq 6+ e impedia o enfileiramento das       
  tarefas. O SynchronizerBuilder foi atualizado para ser robusto e aceitar tanto IDs quanto objetos, garantindo compatibilidade com chamadas legadas.  
                                                                                                                                                       
                                                                                                                                                       
  Contexto e motivação                                                                                                                                 
  Estas alterações foram necessárias para resolver um travamento crítico nas sincronizações do i-Diário (especialmente a sincronização                 
  completa/anual). O problema se manifestava como uma sincronização que ficava presa em 0% "Em andamento" indefinidamente, devido ao fato de o Sidekiq 
  rejeitar o Job por conter objetos complexos que não podiam ser convertidos para JSON para armazenamento no Redis.                                    
                                                                                                                                                       
                                                                                                                                                       
  Tipos de alterações                                                                                                                                  
   - ✅ Correção de bugs (Não quebra outras funcionalidades)                                                                                           
                                                                                                                                                       
                                                                                                                                                       
  Checklist:                                                                                                                                           
   - ✅ Eu li o documento CONTRIBUTING. [REQUIRED]                                                                                                     
   - ✅ Meu código segue o style guide. [REQUIRED]                                                                                                     
   - ✅ Todos os testes novos e existentes estão passando. [REQUIRED]                                                                                  
   - ✅ Criei testes que cobrem minhas alterações. (Validação realizada via execução manual em ambiente de produção)