### PR TITLE
Fix maintenance adjustments new form rendering

### DIFF
--- a/app/views/maintenance_adjustments/_form.html.erb
+++ b/app/views/maintenance_adjustments/_form.html.erb
@@ -7,10 +7,10 @@
 
   <fieldset>
     <div>
-      <% if f.object.error_message.present? %>
+      <% if f.object.try(:error_message).present? %>
         <p class='alert alert-danger'>
           <i class='fa-fw fa fa-times'></i>
-          <span><%= f.object.error_message %></span>
+          <span><%= f.object.try(:error_message) %></span>
         </p>
       <% end %>
       <p id='maintenance_adjustment_info' class='alert alert-info hidden'>

--- a/spec/controllers/maintenance_adjustments_controller_spec.rb
+++ b/spec/controllers/maintenance_adjustments_controller_spec.rb
@@ -3,13 +3,14 @@ require 'rails_helper'
 RSpec.describe MaintenanceAdjustmentsController, type: :controller do
   let(:entity) { Entity.find_by(domain: 'test.host') }
   let(:unity) { create(:unity) }
+  let(:current_school_year) { Date.current.year }
   let(:user) do
     create(
       :user,
       :with_user_role_administrator,
       admin: true,
       current_unity_id: unity.id,
-      current_school_year: 2026
+      current_school_year: current_school_year
     )
   end
 

--- a/spec/controllers/maintenance_adjustments_controller_spec.rb
+++ b/spec/controllers/maintenance_adjustments_controller_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceAdjustmentsController, type: :controller do
+  let(:entity) { Entity.find_by(domain: 'test.host') }
+  let(:unity) { create(:unity) }
+  let(:user) do
+    create(
+      :user,
+      :with_user_role_administrator,
+      admin: true,
+      current_unity_id: unity.id,
+      current_school_year: 2026
+    )
+  end
+
+  around(:each) do |example|
+    entity.using_connection do
+      example.run
+    end
+  end
+
+  before do
+    sign_in(user)
+    allow(controller).to receive(:authorize).and_return(true)
+    request.env['REQUEST_PATH'] = ''
+    unity
+  end
+
+  describe 'GET #new' do
+    it 'renders the form even when the model does not expose error_message' do
+      get :new, params: { locale: 'pt-BR' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(assigns(:maintenance_adjustment).status).to eq(MaintenanceAdjustmentStatus::PENDING)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- guard the maintenance adjustments form against models that do not expose `error_message`
- add a controller spec covering `GET /manutencao-ajustes/novo`

## Problem
The maintenance adjustments form partial calls `f.object.error_message`, but `MaintenanceAdjustment` does not define that method or a backing column. In production this raises during render and the global exception handler redirects the user back to the dashboard with the generic error flash.

## Fix
Use `try(:error_message)` in the partial so the alert is only rendered when the model actually exposes that field.

## Validation
- reproduced the failure against a live i-Diario deployment before the fix
- validated the fixed behavior in the live deployment after patching
- added a controller regression spec for `GET #new`
- I could not run the spec suite locally here because Ruby/Bundler are not available in this environment