### PR TITLE
Corrige fluxo de manutencao/ajustes

### DIFF
--- a/app/controllers/maintenance_adjustments_controller.rb
+++ b/app/controllers/maintenance_adjustments_controller.rb
@@ -17,7 +17,7 @@ class MaintenanceAdjustmentsController < ApplicationController
   end
 
   def create
-    @maintenance_adjustment = MaintenanceAdjustment.new(maintenance_adjustment_params)
+    @maintenance_adjustment = MaintenanceAdjustment.new(maintenance_adjustment_params.merge(workflow_attributes))
     authorize @maintenance_adjustment
 
     if @maintenance_adjustment.save
@@ -29,7 +29,7 @@ class MaintenanceAdjustmentsController < ApplicationController
   end
 
   def update
-    if @maintenance_adjustment.update(maintenance_adjustment_params)
+    if @maintenance_adjustment.update(maintenance_adjustment_params.merge(workflow_attributes))
       start_maintenance_adjustment
       respond_with @maintenance_adjustment, location: maintenance_adjustments_path, notice: t('.notice')
     else
@@ -58,8 +58,10 @@ class MaintenanceAdjustmentsController < ApplicationController
   end
 
   def maintenance_adjustment_params
-    _params = params.require(:maintenance_adjustment).permit(:year, :kind, :observations, :status, :unity_ids)
-    _params[:unity_ids] = _params[:unity_ids].split(",")
+    _params = params.require(:maintenance_adjustment).permit(:year, :kind, :observations, :unity_ids)
+    # O select2 customizado envia os ids como string separada por virgulas, mas
+    # a associacao HABTM espera receber um array.
+    _params[:unity_ids] = normalize_unity_ids(_params[:unity_ids])
     _params
   end
 
@@ -69,5 +71,16 @@ class MaintenanceAdjustmentsController < ApplicationController
 
   def start_maintenance_adjustment
     MaintenanceAdjustmentWorker.perform_async(current_entity.id, maintenance_adjustment_params[:unity_ids], current_user.id, @maintenance_adjustment.id)
+  end
+
+  def normalize_unity_ids(unity_ids)
+    Array(unity_ids).flat_map { |value| value.to_s.split(',') }.reject(&:blank?)
+  end
+
+  def workflow_attributes
+    {
+      status: MaintenanceAdjustmentStatus::PENDING,
+      error_message: nil
+    }
   end
 end

--- a/app/decorators/maintenance_adjustment_decorator.rb
+++ b/app/decorators/maintenance_adjustment_decorator.rb
@@ -27,13 +27,18 @@ class MaintenanceAdjustmentDecorator
       when MaintenanceAdjustmentStatus::ERROR then 'danger'
     end
 
-    content_tag(
-      :p,
-      spin << MaintenanceAdjustmentStatus.t(component.status),
+    html_options = {
       class: 'label label-list label-' << status_class,
       :'data-column' => 'situation',
       :'data-value' => component.status,
       :'data-id' => component.id
+    }
+    html_options[:title] = component.error_message if component.error? && component.error_message.present?
+
+    content_tag(
+      :p,
+      spin << MaintenanceAdjustmentStatus.t(component.status),
+      html_options
     ).html_safe
   end
 end

--- a/app/enumerations/features.rb
+++ b/app/enumerations/features.rb
@@ -35,6 +35,7 @@ class Features < EnumerateIt::Base
                    :knowledge_area_lesson_plans,
                    :knowledge_area_teaching_plans,
                    :learning_objectives_and_skills,
+                   :maintenance_adjustments,
                    :observation_diary_records,
                    :observation_record_report,
                    :partial_score_record_report,

--- a/app/models/maintenance_adjustment.rb
+++ b/app/models/maintenance_adjustment.rb
@@ -23,4 +23,33 @@ class MaintenanceAdjustment < ApplicationRecord
   def to_s
     MaintenanceAdjustmentKinds.t(kind)
   end
+
+  def mark_as_in_progress!
+    persist_workflow_state!(
+      status: MaintenanceAdjustmentStatus::IN_PROGRESS,
+      error_message: nil
+    )
+  end
+
+  def mark_as_completed!
+    persist_workflow_state!(
+      status: MaintenanceAdjustmentStatus::COMPLETED,
+      error_message: nil
+    )
+  end
+
+  def mark_as_error!(message)
+    persist_workflow_state!(
+      status: MaintenanceAdjustmentStatus::ERROR,
+      error_message: message
+    )
+  end
+
+  private
+
+  # As mudancas de estado acontecem fora do ciclo da request, entao nao devem
+  # depender das validacoes do formulario original.
+  def persist_workflow_state!(attributes)
+    update_columns(attributes.merge(updated_at: Time.current))
+  end
 end

--- a/app/services/features_access_levels.rb
+++ b/app/services/features_access_levels.rb
@@ -74,6 +74,7 @@ class FeaturesAccessLevels
       :data_exportations,
       :entity_configurations,
       :general_configurations,
+      :maintenance_adjustments,
       :roles,
       :unities,
       :terms_dictionaries,

--- a/app/views/maintenance_adjustments/_form.html.erb
+++ b/app/views/maintenance_adjustments/_form.html.erb
@@ -10,7 +10,7 @@
       <% if f.object.error_message.present? %>
         <p class='alert alert-danger'>
           <i class='fa-fw fa fa-times'></i>
-          <span><%= f.object.error_message %></span>
+          <span><%= format_error_message(f.object.error_message) %></span>
         </p>
       <% end %>
       <p id='maintenance_adjustment_info' class='alert alert-info hidden'>
@@ -21,7 +21,6 @@
     </div>
     <div class='row'>
       <div class='col col-sm-2'>
-          <%= f.hidden_field :status %>
           <%= f.input :year, as: :integer %>
       </div>
       <div class='col col-sm-4'>

--- a/app/workers/maintenance_adjustment_worker.rb
+++ b/app/workers/maintenance_adjustment_worker.rb
@@ -6,36 +6,33 @@ class MaintenanceAdjustmentWorker
       maintenance_adjustment = MaintenanceAdjustment.find(maintenance_adjustment_id)
 
       begin
-        maintenance_adjustment.update(status: MaintenanceAdjustmentStatus::IN_PROGRESS)
+        maintenance_adjustment.mark_as_in_progress!
 
         if maintenance_adjustment.absence_adjustments?
           AbsenceAdjustmentsService.adjust(unities, maintenance_adjustment.year)
         end
 
-        maintenance_adjustment.update(
-          status: MaintenanceAdjustmentStatus::COMPLETED,
-          error_message: ''
-        )
+        maintenance_adjustment.mark_as_completed!
 
-        notify_on_message(maintenance_adjustment, user_id)
+        notify_on_message(maintenance_adjustment, user_id, success: true)
       rescue StandardError => error
         Honeybadger.notify(error)
 
-        maintenance_adjustment.update(
-          status: MaintenanceAdjustmentStatus::ERROR,
-          error_message: error.message
-        )
+        maintenance_adjustment.mark_as_error!(error.message)
+        notify_on_message(maintenance_adjustment, user_id, success: false, error_message: error.message)
       end
     end
   end
 
   private
 
-  def notify_on_message(maintenance_adjustment, user_id)
+  def notify_on_message(maintenance_adjustment, user_id, success:, error_message: nil)
+    scope = success ? 'maintenance_adjustment_worker.success' : 'maintenance_adjustment_worker.error'
+
     SystemNotificationCreator.create!(
       source: maintenance_adjustment,
-      title: I18n.t('maintenance_adjustment_worker.title'),
-      description: I18n.t('maintenance_adjustment_worker.description'),
+      title: I18n.t("#{scope}.title"),
+      description: I18n.t("#{scope}.description", error_message: error_message),
       users: [User.find(user_id)]
     )
   end

--- a/config/locales/workers/maintenance_adjustment_worker.yml
+++ b/config/locales/workers/maintenance_adjustment_worker.yml
@@ -1,4 +1,8 @@
 pt-BR:
   maintenance_adjustment_worker:
-    title: 'Ajustes realizados com sucesso'
-    description: 'Os ajustes solicitados foram realizados com sucesso.'
+    success:
+      title: 'Ajustes realizados com sucesso'
+      description: 'Os ajustes solicitados foram realizados com sucesso.'
+    error:
+      title: 'Ocorreu um erro ao realizar os ajustes'
+      description: 'Os ajustes solicitados não puderam ser concluídos. Motivo: %{error_message}.'

--- a/db/migrate/20260322200000_add_error_message_to_maintenance_adjustments.rb
+++ b/db/migrate/20260322200000_add_error_message_to_maintenance_adjustments.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToMaintenanceAdjustments < ActiveRecord::Migration[4.2]
+  def change
+    add_column :maintenance_adjustments, :error_message, :text
+  end
+end

--- a/spec/controllers/maintenance_adjustments_controller_spec.rb
+++ b/spec/controllers/maintenance_adjustments_controller_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceAdjustmentsController, type: :controller do
+  let(:entity) { Entity.find_by(domain: 'test.host') }
+  let(:unity) { create(:unity) }
+  let(:current_school_year) { Date.current.year }
+  let(:user) do
+    create(
+      :user,
+      :with_user_role_administrator,
+      admin: true,
+      current_unity_id: unity.id,
+      current_school_year: current_school_year
+    )
+  end
+
+  around(:each) do |example|
+    entity.using_connection do
+      example.run
+    end
+  end
+
+  before do
+    sign_in(user)
+    allow(controller).to receive(:authorize).and_return(true)
+    request.env['REQUEST_PATH'] = ''
+    unity
+  end
+
+  describe 'GET #new' do
+    it 'renderiza o formulário de novo ajuste com status pendente' do
+      get :new, params: { locale: 'pt-BR' }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(assigns(:maintenance_adjustment).status).to eq(MaintenanceAdjustmentStatus::PENDING)
+    end
+  end
+
+  describe 'POST #create' do
+    it 'trata unity_ids em branco sem levantar excecao' do
+      allow(MaintenanceAdjustmentWorker).to receive(:perform_async)
+
+      post :create, params: {
+        locale: 'pt-BR',
+        maintenance_adjustment: {
+          year: current_school_year,
+          kind: MaintenanceAdjustmentKinds::ABSENCE_ADJUSTMENTS,
+          observations: 'Retrying adjustments after reviewing the rules',
+          unity_ids: nil
+        }
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+      expect(MaintenanceAdjustmentWorker).not_to have_received(:perform_async)
+    end
+  end
+end

--- a/spec/services/features_access_levels_spec.rb
+++ b/spec/services/features_access_levels_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe FeaturesAccessLevels do
+  describe '.administrator_features' do
+    it 'inclui maintenance_adjustments nas permissoes de administrador' do
+      expect(described_class.administrator_features).to include(:maintenance_adjustments)
+    end
+  end
+
+  describe '.employee_features' do
+    it 'mantem maintenance_adjustments restrito a administradores' do
+      expect(described_class.employee_features).not_to include(:maintenance_adjustments)
+    end
+  end
+end

--- a/spec/workers/maintenance_adjustment_worker_spec.rb
+++ b/spec/workers/maintenance_adjustment_worker_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe MaintenanceAdjustmentWorker do
+  let(:entity) { Entity.find_by(domain: 'test.host') }
+
+  around(:each) do |example|
+    entity.using_connection do
+      example.run
+    end
+  end
+
+  describe '#perform' do
+    let(:user) { create(:user, :with_user_role_administrator) }
+    let(:unity) { create(:unity) }
+    let(:maintenance_adjustment) do
+      MaintenanceAdjustment.create!(
+        year: Date.current.year,
+        kind: MaintenanceAdjustmentKinds::ABSENCE_ADJUSTMENTS,
+        observations: 'Adjust absences after fixing an exam rule',
+        status: MaintenanceAdjustmentStatus::PENDING,
+        unities: [unity]
+      )
+    end
+
+    before do
+      allow(SystemNotificationCreator).to receive(:create!)
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'marca o ajuste como concluido e limpa a mensagem de erro persistida' do
+      allow(AbsenceAdjustmentsService).to receive(:adjust)
+
+      described_class.new.perform(entity.id, [unity.id], user.id, maintenance_adjustment.id)
+
+      maintenance_adjustment.reload
+
+      expect(maintenance_adjustment.status).to eq(MaintenanceAdjustmentStatus::COMPLETED)
+      expect(maintenance_adjustment.error_message).to be_nil
+      expect(AbsenceAdjustmentsService).to have_received(:adjust).with([unity.id], maintenance_adjustment.year)
+      expect(SystemNotificationCreator).to have_received(:create!).with(
+        hash_including(
+          source: maintenance_adjustment,
+          title: I18n.t('maintenance_adjustment_worker.success.title'),
+          description: I18n.t('maintenance_adjustment_worker.success.description'),
+          users: [user]
+        )
+      )
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+
+    it 'marca o ajuste como erro, persiste a mensagem e notifica o usuario' do
+      allow(AbsenceAdjustmentsService).to receive(:adjust).and_raise(StandardError, 'Regra de avaliacao inconsistente')
+
+      described_class.new.perform(entity.id, [unity.id], user.id, maintenance_adjustment.id)
+
+      maintenance_adjustment.reload
+
+      expect(maintenance_adjustment.status).to eq(MaintenanceAdjustmentStatus::ERROR)
+      expect(maintenance_adjustment.error_message).to eq('Regra de avaliacao inconsistente')
+      expect(Honeybadger).to have_received(:notify).with(instance_of(StandardError))
+      expect(SystemNotificationCreator).to have_received(:create!).with(
+        hash_including(
+          source: maintenance_adjustment,
+          title: I18n.t('maintenance_adjustment_worker.error.title'),
+          description: I18n.t(
+            'maintenance_adjustment_worker.error.description',
+            error_message: 'Regra de avaliacao inconsistente'
+          ),
+          users: [user]
+        )
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Resumo
Corrige a funcionalidade de manutencao/ajustes de ponta a ponta, atacando a causa raiz do problema em vez de apenas esconder a excecao da tela `novo`.

## Problema
A feature estava inconsistente em mais de um ponto:
- a view acessava `error_message`, mas `MaintenanceAdjustment` nao tinha essa coluna no banco
- o worker tambem tentava persistir `error_message`, o que deixava a execucao assicrona estruturalmente quebrada
- o `status` era aceito do request, embora devesse ser controlado pelo fluxo interno da rotina
- `unity_ids` era tratado de forma fragil, assumindo sempre uma string preenchida
- a feature aparecia na navegacao, mas nao existia na enum central de features/permissoes

## O que foi feito
- adiciona migration para persistir `error_message` em `maintenance_adjustments`
- formaliza transicoes de estado no model (`mark_as_in_progress!`, `mark_as_completed!`, `mark_as_error!`) com persistencia independente das validacoes do formulario
- faz o controller controlar `status` e limpar `error_message` ao reenfileirar a rotina
- normaliza `unity_ids` de forma segura para lidar com `nil`, string vazia ou lista vinda do select2
- remove a dependencia do hidden field de `status` no formulario
- melhora a exibicao do erro:
  - formulario volta a mostrar a mensagem persistida de erro
  - label de status passa a carregar a mensagem como `title` quando houver falha
- ajusta o worker para:
  - usar as transicoes centralizadas do model
  - limpar erro anterior em novo processamento
  - notificar usuario tanto em sucesso quanto em erro
- inclui `maintenance_adjustments` na enum de features e a mantem restrita a administradores em `FeaturesAccessLevels`

## Cobertura adicionada
- spec de controller para garantir que a tela `new` renderiza com `status` pendente
- spec de controller para garantir que `unity_ids` em branco nao derruba o `create`
- spec de worker cobrindo fluxo de sucesso e fluxo de erro
- spec de `FeaturesAccessLevels` cobrindo a visibilidade administrativa da feature

## Como validar
1. Rodar a migration nova.
2. Acessar `manutencao-ajustes/novo` e confirmar que a tela abre normalmente.
3. Criar um ajuste valido e confirmar que ele vai para processamento.
4. Simular erro no worker e confirmar que:
   - o status vira `error`
   - `error_message` fica persistido
   - a mensagem reaparece ao editar o ajuste
   - o usuario recebe notificacao de falha

## Observacoes
- Nao consegui rodar a suite localmente neste ambiente porque `ruby` e `bundle` nao estao instalados na maquina usada para preparar o patch.
- Mantive a feature como restrita a administradores para preservar o comportamento mais conservador que ja existia na pratica.