### PR TITLE
Considera a regra diferenciada ao filtrar turmas por tipo de nota

### DIFF
--- a/app/models/classrooms_grade.rb
+++ b/app/models/classrooms_grade.rb
@@ -14,7 +14,27 @@ class ClassroomsGrade < ApplicationRecord
   default_scope -> { kept }
 
   scope :by_classroom_id, ->(classroom_id) { where(classroom_id: classroom_id) }
-  scope :by_score_type, ->(score_type) { joins(:exam_rule).where(exam_rules: { score_type: score_type }) }
+  scope :by_score_type, lambda { |score_type|
+    joins(:exam_rule)
+      .joins(
+        'LEFT JOIN exam_rules differentiated_exam_rules ' \
+        'ON differentiated_exam_rules.id = exam_rules.differentiated_exam_rule_id'
+      )
+      .where(
+        'exam_rules.score_type IN (:score_type) OR (
+           differentiated_exam_rules.score_type IN (:score_type) AND EXISTS (
+             SELECT 1
+             FROM student_enrollment_classrooms
+             JOIN student_enrollments
+               ON student_enrollments.id = student_enrollment_classrooms.student_enrollment_id
+             JOIN students ON students.id = student_enrollments.student_id
+             WHERE student_enrollment_classrooms.classrooms_grade_id = classrooms_grades.id
+               AND students.uses_differentiated_exam_rule = TRUE
+           )
+         )',
+        score_type: Array(score_type)
+      )
+  }
   scope :by_grade_id, ->(grade_id) { where(grade_id: grade_id) }
   scope :by_opinion_type, ->(opinion_type) { joins(:exam_rule).where(exam_rules: { opinion_type: opinion_type }) }
   scope :by_exam_rule, ->(exam_rule_id) { joins(:exam_rule).where(exam_rules: { id: exam_rule_id }) }

--- a/spec/models/classrooms_grade_spec.rb
+++ b/spec/models/classrooms_grade_spec.rb
@@ -7,6 +7,43 @@ RSpec.describe ClassroomsGrade, type: :model do
     it { expect(subject).to respond_to(:exam_rule_id) }
   end
 
+  describe '.by_score_type' do
+    # Regra regular numerica cuja regra DIFERENCIADA e conceitual: e o arranjo que
+    # o i-Educar sincroniza quando a escola nao marca "utiliza regra diferenciada".
+    let(:concept_exam_rule) { create(:exam_rule, :score_type_concept) }
+    let(:numeric_exam_rule_with_differentiated) do
+      create(:exam_rule, differentiated_exam_rule: concept_exam_rule)
+    end
+
+    def enroll_student(classrooms_grade, uses_differentiated_exam_rule:)
+      student = create(:student, uses_differentiated_exam_rule: uses_differentiated_exam_rule)
+
+      create(
+        :student_enrollment_classroom,
+        classrooms_grade: classrooms_grade,
+        student_enrollment: create(:student_enrollment, student: student)
+      )
+    end
+
+    it 'includes the grade when the differentiated exam rule matches and an enrolled student uses it' do
+      classrooms_grade = create(:classrooms_grade, exam_rule: numeric_exam_rule_with_differentiated)
+      enroll_student(classrooms_grade, uses_differentiated_exam_rule: true)
+
+      result = described_class.by_score_type([ScoreTypes::CONCEPT, ScoreTypes::NUMERIC_AND_CONCEPT])
+
+      expect(result).to include(classrooms_grade)
+    end
+
+    it 'excludes the grade when the differentiated exam rule matches but no enrolled student uses it' do
+      classrooms_grade = create(:classrooms_grade, exam_rule: numeric_exam_rule_with_differentiated)
+      enroll_student(classrooms_grade, uses_differentiated_exam_rule: false)
+
+      result = described_class.by_score_type([ScoreTypes::CONCEPT, ScoreTypes::NUMERIC_AND_CONCEPT])
+
+      expect(result).to_not include(classrooms_grade)
+    end
+  end
+
   describe 'associations' do
     it { expect(subject).to belong_to(:classroom) }
     it { expect(subject).to belong_to(:grade) }


### PR DESCRIPTION
## Descrição

O escopo `ClassroomsGrade.by_score_type` passa a considerar também a regra de avaliação diferenciada da turma, e não apenas a regra regular. A ampliação é condicionada: a turma só entra no resultado pela regra diferenciada quando existe aluno matriculado nela com `uses_differentiated_exam_rule` verdadeiro.

Antes:

```ruby
scope :by_score_type, lambda { |score_type|
  joins(:exam_rule).where(exam_rules: { score_type: score_type })
}
```

Depois, em resumo: `LEFT JOIN` na regra diferenciada, e a condição aceita a turma quando o tipo de nota bate na regra regular, ou quando bate na diferenciada e existe `EXISTS` de aluno matriculado que a utiliza.

## Contexto e motivação

Corrige a #185.

Em turma cuja regra regular é numérica e cuja regra diferenciada é conceitual, a listagem de avaliações conceituais do professor filtra as turmas por tipo de nota conceitual, não encontra a turma e devolve vazio. Os lançamentos existem no banco, e é por isso que a tentativa de lançar novamente acusa avaliação já existente.

Administradores, gestores e coordenadores continuam enxergando os registros porque o acesso deles não passa por esse filtro de turmas. A diferença de visão entre perfis, relatada na #185, é consequência e não causa.

A condição do `EXISTS` existe para que o filtro não seja afrouxado: turma cuja regra diferenciada é conceitual mas que não tem nenhum aluno usando essa regra continua fora do resultado.

## Tipos de alterações

- Correção de bugs (Não quebra outras funcionalidades)

## Validação

Foram adicionados dois cenários em `spec/models/classrooms_grade_spec.rb`:

- a turma aparece quando a regra diferenciada é conceitual e há aluno matriculado que a utiliza;
- a turma não aparece quando a regra diferenciada é conceitual e nenhum aluno matriculado a utiliza.

O segundo cenário é a guarda contra o filtro virar um passa-tudo.

Foram executados os specs do modelo alterado, `spec/models/classrooms_grade_spec.rb`, sem falhas. A suíte completa não foi executada neste ambiente, ficando a cargo da integração contínua do projeto.

A alteração está em uso em ambiente de produção, onde a listagem do professor voltou a apresentar os lançamentos que estavam invisíveis.

## Checklist

- Eu li o documento **CONTRIBUTING**. **[REQUIRED]**
- Meu código segue o style guide. **[REQUIRED]**
- Os testes do modelo alterado, novos e existentes, estão passando. **[REQUIRED]**
- Criei testes que cobrem minhas alterações.

Closes #185
